### PR TITLE
Add textEditor tool that combines readFile and updateFile functionality

### DIFF
--- a/.changeset/text-editor.md
+++ b/.changeset/text-editor.md
@@ -1,0 +1,5 @@
+---
+"mycoder-agent": minor
+---
+
+Add textEditor tool that combines readFile and updateFile functionality

--- a/packages/agent/src/tools/getTools.ts
+++ b/packages/agent/src/tools/getTools.ts
@@ -6,6 +6,7 @@ import { subAgentTool } from './interaction/subAgent.js';
 import { userPromptTool } from './interaction/userPrompt.js';
 import { fetchTool } from './io/fetch.js';
 import { readFileTool } from './io/readFile.js';
+import { textEditorTool } from './io/textEditor.js';
 import { updateFileTool } from './io/updateFile.js';
 import { respawnTool } from './system/respawn.js';
 import { sequenceCompleteTool } from './system/sequenceComplete.js';
@@ -15,6 +16,7 @@ import { sleepTool } from './system/sleep.js';
 
 export function getTools(): Tool[] {
   return [
+    textEditorTool,
     subAgentTool,
     readFileTool,
     updateFileTool,

--- a/packages/agent/src/tools/io/textEditor.test.ts
+++ b/packages/agent/src/tools/io/textEditor.test.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from 'crypto';
+import { mkdtemp, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { TokenTracker } from '../../core/tokens.js';
+import { ToolContext } from '../../core/types.js';
+import { MockLogger } from '../../utils/mockLogger.js';
+import { shellExecuteTool } from '../system/shellExecute.js';
+
+import { textEditorTool } from './textEditor.js';
+
+const toolContext: ToolContext = {
+  logger: new MockLogger(),
+  headless: true,
+  workingDirectory: '.',
+  userSession: false,
+  pageFilter: 'simple',
+  tokenTracker: new TokenTracker(),
+};
+
+describe('textEditor', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'texteditor-test-'));
+  });
+
+  afterEach(async () => {
+    await shellExecuteTool.execute(
+      { command: `rm -rf "${testDir}"`, description: 'test' },
+      toolContext,
+    );
+  });
+
+  it('should create a file', async () => {
+    const testContent = 'test content';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create the file
+    const result = await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: testContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('File created');
+
+    // Verify content
+    const content = await readFile(testPath, 'utf8');
+    expect(content).toBe(testContent);
+  });
+
+  it('should view a file', async () => {
+    const testContent = 'line 1\nline 2\nline 3';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create the file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: testContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // View the file
+    const result = await textEditorTool.execute(
+      {
+        command: 'view',
+        path: testPath,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.content).toContain('1: line 1');
+    expect(result.content).toContain('2: line 2');
+    expect(result.content).toContain('3: line 3');
+  });
+
+  it('should view a file with range', async () => {
+    const testContent = 'line 1\nline 2\nline 3\nline 4\nline 5';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create the file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: testContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // View the file with range
+    const result = await textEditorTool.execute(
+      {
+        command: 'view',
+        path: testPath,
+        view_range: [2, 4],
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.content).not.toContain('1: line 1');
+    expect(result.content).toContain('2: line 2');
+    expect(result.content).toContain('3: line 3');
+    expect(result.content).toContain('4: line 4');
+    expect(result.content).not.toContain('5: line 5');
+  });
+
+  it('should replace text in a file', async () => {
+    const initialContent = 'Hello world! This is a test.';
+    const oldStr = 'world';
+    const newStr = 'universe';
+    const expectedContent = 'Hello universe! This is a test.';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create initial file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: initialContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Replace text
+    const result = await textEditorTool.execute(
+      {
+        command: 'str_replace',
+        path: testPath,
+        old_str: oldStr,
+        new_str: newStr,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Successfully replaced');
+
+    // Verify content
+    const content = await readFile(testPath, 'utf8');
+    expect(content).toBe(expectedContent);
+  });
+
+  it('should insert text at a specific line', async () => {
+    const initialContent = 'line 1\nline 2\nline 4';
+    const insertLine = 2; // After "line 2"
+    const newStr = 'line 3';
+    const expectedContent = 'line 1\nline 2\nline 3\nline 4';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create initial file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: initialContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Insert text
+    const result = await textEditorTool.execute(
+      {
+        command: 'insert',
+        path: testPath,
+        insert_line: insertLine,
+        new_str: newStr,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Successfully inserted');
+
+    // Verify content
+    const content = await readFile(testPath, 'utf8');
+    expect(content).toBe(expectedContent);
+  });
+
+  it('should undo an edit', async () => {
+    const initialContent = 'Hello world!';
+    const modifiedContent = 'Hello universe!';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create initial file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: initialContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Modify the file
+    await textEditorTool.execute(
+      {
+        command: 'str_replace',
+        path: testPath,
+        old_str: 'world',
+        new_str: 'universe',
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify modified content
+    let content = await readFile(testPath, 'utf8');
+    expect(content).toBe(modifiedContent);
+
+    // Undo the edit
+    const result = await textEditorTool.execute(
+      {
+        command: 'undo_edit',
+        path: testPath,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Successfully reverted');
+
+    // Verify content is back to initial
+    content = await readFile(testPath, 'utf8');
+    expect(content).toBe(initialContent);
+  });
+
+  it('should handle errors for non-existent files', async () => {
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Try to view a non-existent file
+    const result = await textEditorTool.execute(
+      {
+        command: 'view',
+        path: testPath,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('should handle errors for duplicate string replacements', async () => {
+    const initialContent = 'Hello world! This is a world test.';
+    const oldStr = 'world';
+    const newStr = 'universe';
+    const testPath = join(testDir, `${randomUUID()}.txt`);
+
+    // Create initial file
+    await textEditorTool.execute(
+      {
+        command: 'create',
+        path: testPath,
+        file_text: initialContent,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Try to replace text with multiple occurrences
+    const result = await textEditorTool.execute(
+      {
+        command: 'str_replace',
+        path: testPath,
+        old_str: oldStr,
+        new_str: newStr,
+        description: 'test',
+      },
+      toolContext,
+    );
+
+    // Verify return value
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Found 2 occurrences');
+  });
+});

--- a/packages/agent/src/tools/io/textEditor.ts
+++ b/packages/agent/src/tools/io/textEditor.ts
@@ -1,0 +1,337 @@
+import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { Tool } from '../../core/types.js';
+
+const OUTPUT_LIMIT = 10 * 1024; // 10KB limit
+
+// Store file states for undo functionality
+const fileStateHistory: Record<string, string[]> = {};
+
+const parameterSchema = z.object({
+  command: z
+    .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
+    .describe(
+      'The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.',
+    ),
+  path: z
+    .string()
+    .describe('Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.'),
+  file_text: z
+    .string()
+    .optional()
+    .describe(
+      'Required parameter of `create` command, with the content of the file to be created.',
+    ),
+  insert_line: z
+    .number()
+    .optional()
+    .describe(
+      'Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.',
+    ),
+  new_str: z
+    .string()
+    .optional()
+    .describe(
+      'Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.',
+    ),
+  old_str: z
+    .string()
+    .optional()
+    .describe(
+      'Required parameter of `str_replace` command containing the string in `path` to replace.',
+    ),
+  view_range: z
+    .array(z.number())
+    .optional()
+    .describe(
+      'Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.',
+    ),
+  description: z
+    .string()
+    .max(80)
+    .describe('The reason you are using the text editor (max 80 chars)'),
+});
+
+const returnSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  content: z.string().optional(),
+});
+
+type Parameters = z.infer<typeof parameterSchema>;
+type ReturnType = z.infer<typeof returnSchema>;
+
+export const textEditorTool: Tool<Parameters, ReturnType> = {
+  name: 'textEditor',
+  description:
+    'View, create, and edit files with persistent state across command calls',
+  logPrefix: '📝',
+  parameters: zodToJsonSchema(parameterSchema),
+  returns: zodToJsonSchema(returnSchema),
+  execute: async (
+    { command, path: filePath, file_text, insert_line, new_str, old_str, view_range },
+    context,
+  ) => {
+    const normalizedPath = path.normalize(filePath);
+    const absolutePath = path.isAbsolute(normalizedPath)
+      ? normalizedPath
+      : context?.workingDirectory
+        ? path.join(context.workingDirectory, normalizedPath)
+        : path.resolve(normalizedPath);
+
+    try {
+      switch (command) {
+        case 'view': {
+          // Check if path is a directory
+          const stats = await fs.stat(absolutePath).catch(() => null);
+          if (!stats) {
+            return {
+              success: false,
+              message: `File or directory not found: ${filePath}`,
+            };
+          }
+
+          if (stats.isDirectory()) {
+            // List directory contents up to 2 levels deep
+            try {
+              const output = execSync(
+                `find "${absolutePath}" -type f -not -path "*/\\.*" -maxdepth 2 | sort`,
+                { encoding: 'utf8' },
+              );
+              return {
+                success: true,
+                message: `Directory listing for ${filePath}:`,
+                content: output,
+              };
+            } catch (error) {
+              return {
+                success: false,
+                message: `Error listing directory: ${error}`,
+              };
+            }
+          } else {
+            // Read file content
+            const content = await fs.readFile(absolutePath, 'utf8');
+            const lines = content.split('\n');
+
+            // Apply view range if specified
+            let displayContent = content;
+            if (view_range && view_range.length === 2) {
+              const [start, end] = view_range;
+              const startLine = Math.max(1, start || 1) - 1; // Convert to 0-indexed
+              const endLine = end === -1 ? lines.length : end;
+              displayContent = lines
+                .slice(startLine, endLine)
+                .join('\n');
+            }
+
+            // Add line numbers
+            const startLineNum = view_range && view_range.length === 2 ? view_range[0] : 1;
+            const numberedContent = displayContent
+              .split('\n')
+              .map((line, i) => `${(startLineNum || 1) + i}: ${line}`)
+              .join('\n');
+
+            // Truncate if too large
+            if (numberedContent.length > OUTPUT_LIMIT) {
+              const truncatedContent = numberedContent.substring(0, OUTPUT_LIMIT);
+              return {
+                success: true,
+                message: `File content (truncated):`,
+                content: `${truncatedContent}\n<response clipped>`,
+              };
+            }
+
+            return {
+              success: true,
+              message: `File content:`,
+              content: numberedContent,
+            };
+          }
+        }
+
+        case 'create': {
+          // Check if file already exists
+          if (fsSync.existsSync(absolutePath)) {
+            return {
+              success: false,
+              message: `File already exists: ${filePath}. Use str_replace to modify it.`,
+            };
+          }
+
+          if (!file_text) {
+            return {
+              success: false,
+              message: 'file_text parameter is required for create command',
+            };
+          }
+
+          // Create parent directories if they don't exist
+          await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+
+          // Create the file
+          await fs.writeFile(absolutePath, file_text, 'utf8');
+
+          // Store initial state for undo
+          fileStateHistory[absolutePath] = [file_text];
+
+          return {
+            success: true,
+            message: `File created: ${filePath}`,
+          };
+        }
+
+        case 'str_replace': {
+          if (!old_str) {
+            return {
+              success: false,
+              message: 'old_str parameter is required for str_replace command',
+            };
+          }
+
+          // Ensure the file exists
+          if (!fsSync.existsSync(absolutePath)) {
+            return {
+              success: false,
+              message: `File not found: ${filePath}`,
+            };
+          }
+
+          // Read the current content
+          const content = await fs.readFile(absolutePath, 'utf8');
+
+          // Check if old_str exists uniquely in the file
+          const occurrences = content.split(old_str).length - 1;
+          if (occurrences === 0) {
+            return {
+              success: false,
+              message: `The specified old_str was not found in the file`,
+            };
+          }
+          if (occurrences > 1) {
+            return {
+              success: false,
+              message: `Found ${occurrences} occurrences of old_str, expected exactly 1`,
+            };
+          }
+
+          // Save current state for undo
+          if (!fileStateHistory[absolutePath]) {
+            fileStateHistory[absolutePath] = [];
+          }
+          fileStateHistory[absolutePath].push(content);
+
+          // Replace the content
+          const updatedContent = content.replace(old_str, new_str || '');
+          await fs.writeFile(absolutePath, updatedContent, 'utf8');
+
+          return {
+            success: true,
+            message: `Successfully replaced text in ${filePath}`,
+          };
+        }
+
+        case 'insert': {
+          if (insert_line === undefined) {
+            return {
+              success: false,
+              message: 'insert_line parameter is required for insert command',
+            };
+          }
+
+          if (!new_str) {
+            return {
+              success: false,
+              message: 'new_str parameter is required for insert command',
+            };
+          }
+
+          // Ensure the file exists
+          if (!fsSync.existsSync(absolutePath)) {
+            return {
+              success: false,
+              message: `File not found: ${filePath}`,
+            };
+          }
+
+          // Read the current content
+          const content = await fs.readFile(absolutePath, 'utf8');
+          const lines = content.split('\n');
+
+          // Validate line number
+          if (insert_line < 0 || insert_line > lines.length) {
+            return {
+              success: false,
+              message: `Invalid line number: ${insert_line}. File has ${lines.length} lines.`,
+            };
+          }
+
+          // Save current state for undo
+          if (!fileStateHistory[absolutePath]) {
+            fileStateHistory[absolutePath] = [];
+          }
+          fileStateHistory[absolutePath].push(content);
+
+          // Insert the new content after the specified line
+          lines.splice(insert_line, 0, new_str);
+          const updatedContent = lines.join('\n');
+          await fs.writeFile(absolutePath, updatedContent, 'utf8');
+
+          return {
+            success: true,
+            message: `Successfully inserted text after line ${insert_line} in ${filePath}`,
+          };
+        }
+
+        case 'undo_edit': {
+          // Check if we have history for this file
+          if (
+            !fileStateHistory[absolutePath] ||
+            fileStateHistory[absolutePath].length === 0
+          ) {
+            return {
+              success: false,
+              message: `No edit history found for ${filePath}`,
+            };
+          }
+
+          // Get the previous state
+          const previousState = fileStateHistory[absolutePath].pop();
+          await fs.writeFile(absolutePath, previousState as string, 'utf8');
+
+          return {
+            success: true,
+            message: `Successfully reverted last edit to ${filePath}`,
+          };
+        }
+
+        default:
+          return {
+            success: false,
+            message: `Unknown command: ${command}`,
+          };
+      }
+    } catch (error: any) {
+      return {
+        success: false,
+        message: `Error: ${error.message}`,
+      };
+    }
+  },
+  logParameters: (input, { logger }) => {
+    logger.info(
+      `${input.command} operation on "${input.path}", ${input.description}`,
+    );
+  },
+  logReturns: (result, { logger }) => {
+    if (!result.success) {
+      logger.error(`Text editor operation failed: ${result.message}`);
+    }
+  },
+};


### PR DESCRIPTION
This PR implements GitHub Issue #59 by creating a new textEditor tool that combines the functionality of readFile and updateFile into a single tool, similar to Anthropic's built-in text editor tool. The new tool provides the following commands:

- view: Display file content with line numbers or directory listing
- create: Create a new file with specified content
- str_replace: Replace specific text in a file (must be unique)
- insert: Insert text at a specific line number
- undo_edit: Revert the last edit made to a file

The tool maintains state across calls, allowing for undo functionality. All tests pass and the tool is fully integrated into the agent.