### PR TITLE
Fix GitHub newlines issue #83 using markdown files approach

### DIFF
--- a/packages/agent/src/core/toolAgent/config.ts
+++ b/packages/agent/src/core/toolAgent/config.ts
@@ -76,6 +76,12 @@ export function getDefaultSystemPrompt(toolContext: ToolContext): string {
         '- Create additional GitHub issues for follow-up tasks or ideas',
         '',
         'You can use the GitHub CLI (`gh`) for all GitHub interactions.',
+        '',
+        'When creating GitHub issues, PRs, or comments, use temporary markdown files for the content instead of inline text:',
+        '- Create a temporary markdown file with the content you want to include',
+        '- Use the file with GitHub CLI commands (e.g., `gh issue create --body-file temp.md`)',
+        '- Clean up the temporary file when done',
+        '- This approach preserves formatting, newlines, and special characters correctly',
       ].join('\n')
     : '';
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,6 +61,29 @@ Requirements for GitHub mode:
 - GitHub CLI (`gh`) needs to be installed and authenticated
 - User needs to have appropriate GitHub permissions for the target repository
 
+When using GitHub mode, MyCoder uses temporary markdown files for creating issues, PRs, and comments to ensure proper formatting:
+
+```bash
+# Example of how MyCoder handles GitHub content
+# 1. Creates a temporary markdown file
+cat > temp.md << 'EOF'
+## Description
+This is a description with proper
+newlines and formatting.
+
+- Bullet point 1
+- Bullet point 2
+EOF
+
+# 2. Uses the file with GitHub CLI
+gh issue create --title "Issue Title" --body-file temp.md
+
+# 3. Cleans up the temporary file
+rm temp.md
+```
+
+This approach ensures that formatting, newlines, and special characters are preserved correctly in GitHub content.
+
 ## Configuration
 
 MyCoder stores configuration in `~/.mycoder/config.json`. You can manage configuration using the `config` command:

--- a/packages/cli/tests/github-mode-test.md
+++ b/packages/cli/tests/github-mode-test.md
@@ -1,0 +1,36 @@
+# GitHub Mode Markdown File Approach Test
+
+This is a test to verify that using temporary markdown files for GitHub issues, PRs, and comments works correctly.
+
+## Key Benefits
+- Preserves formatting
+- Handles newlines properly
+- Supports special characters
+- More robust than inline text
+
+## Example Usage
+```bash
+# Create a temporary markdown file
+cat > temp.md << 'EOF'
+# Issue Title
+
+## Description
+This is a description with proper
+newlines and formatting.
+
+- Bullet point 1
+- Bullet point 2
+
+```code block
+example code
+```
+EOF
+
+# Use the file with GitHub CLI
+gh issue create --title "Test Issue" --body-file temp.md
+
+# Clean up
+rm temp.md
+```
+
+This approach should fix issue #83.


### PR DESCRIPTION
## Fix for GitHub newlines issue #83 using markdown files approach

This PR implements an alternative approach to fix issue #83 where newlines and formatting in GitHub issues, PRs, and comments weren't being preserved correctly.

### Changes

1. Updated the GitHub mode instructions in the system prompt to use temporary markdown files:
   - Create a temporary markdown file with the content
   - Use the file with GitHub CLI commands (e.g., `gh issue create --body-file temp.md`)
   - Clean up the temporary file when done

2. Added documentation in README.md about this approach with examples

3. Created a test file showing how this approach works

### Benefits

- More robust than trying to escape newlines in inline text
- Preserves formatting, newlines, and special characters correctly
- Works consistently across different platforms (Windows, Linux, macOS)
- Follows standard GitHub CLI practices for handling complex content

Closes #83