### PR TITLE
Fix config tests to include customPrompt field

### DIFF
--- a/packages/cli/tests/settings/config.test.ts
+++ b/packages/cli/tests/settings/config.test.ts
@@ -44,6 +44,7 @@ describe('Config', () => {
         modelProvider: 'anthropic',
         modelName: 'claude-3-7-sonnet-20250219',
         ollamaBaseUrl: 'http://localhost:11434/api',
+        customPrompt: '',
       });
       expect(fs.existsSync).toHaveBeenCalledWith(mockConfigFile);
     });
@@ -76,6 +77,7 @@ describe('Config', () => {
         modelProvider: 'anthropic',
         modelName: 'claude-3-7-sonnet-20250219',
         ollamaBaseUrl: 'http://localhost:11434/api',
+        customPrompt: '',
       });
     });
   });


### PR DESCRIPTION
## Fix config tests to include customPrompt field

This PR fixes the failing tests in the CLI package after the implementation of the customPrompt configuration option in PR #96. 

### Changes
- Updated test expectations in `config.test.ts` to include the new `customPrompt` field that was added to the default configuration

### Testing
- Verified that all tests now pass in the CLI package

Fixes tests after PR #96 (Issue #95)