### PR TITLE
Fix #115: Remove hardcoded Anthropic API key check

### DIFF
--- a/packages/agent/src/core/toolAgent/toolAgentCore.ts
+++ b/packages/agent/src/core/toolAgent/toolAgentCore.ts
@@ -1,7 +1,5 @@
 import { CoreMessage, ToolSet, generateText, tool as makeTool } from 'ai';
 
-import { getAnthropicApiKeyError } from '../../utils/errors.js';
-
 import { DEFAULT_CONFIG } from './config.js';
 import {
   addCacheControlToMessages,
@@ -29,9 +27,6 @@ export const toolAgent = async (
   logger.verbose('Initial prompt:', initialPrompt);
 
   let interactions = 0;
-
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error(getAnthropicApiKeyError());
 
   const messages: CoreMessage[] = [
     {

--- a/packages/agent/src/utils/errors.ts
+++ b/packages/agent/src/utils/errors.ts
@@ -1,10 +1,47 @@
 export const getAnthropicApiKeyError = () => `
 Error: ANTHROPIC_API_KEY environment variable is not set
 
-Before using MyCoder, you must have an ANTHROPIC_API_KEY specified either:
+Before using MyCoder with Anthropic models, you must have an ANTHROPIC_API_KEY specified either:
 
 - As an environment variable, "export ANTHROPIC_API_KEY=[your-api-key]" or
 - In a .env file in the folder you run "mycoder" from
 
 Get an API key from https://www.anthropic.com/api
+For setup instructions, visit: https://mycoder.ai/docs/getting-started/anthropic
+`;
+
+export const getOpenAIApiKeyError = () => `
+Error: OPENAI_API_KEY environment variable is not set
+
+Before using MyCoder with OpenAI models, you must have an OPENAI_API_KEY specified either:
+
+- As an environment variable, "export OPENAI_API_KEY=[your-api-key]" or
+- In a .env file in the folder you run "mycoder" from
+
+Get an API key from https://platform.openai.com/api-keys
+For setup instructions, visit: https://mycoder.ai/docs/getting-started/openai
+`;
+
+export const getXAIApiKeyError = () => `
+Error: XAI_API_KEY environment variable is not set
+
+Before using MyCoder with xAI models, you must have an XAI_API_KEY specified either:
+
+- As an environment variable, "export XAI_API_KEY=[your-api-key]" or
+- In a .env file in the folder you run "mycoder" from
+
+Get an API key from https://platform.xai.com
+For setup instructions, visit: https://mycoder.ai/docs/getting-started/xai
+`;
+
+export const getMistralApiKeyError = () => `
+Error: MISTRAL_API_KEY environment variable is not set
+
+Before using MyCoder with Mistral models, you must have a MISTRAL_API_KEY specified either:
+
+- As an environment variable, "export MISTRAL_API_KEY=[your-api-key]" or
+- In a .env file in the folder you run "mycoder" from
+
+Get an API key from https://console.mistral.ai/api-keys/
+For setup instructions, visit: https://mycoder.ai/docs/getting-started/mistral
 `;

--- a/packages/agent/src/utils/errors.ts
+++ b/packages/agent/src/utils/errors.ts
@@ -1,47 +1,54 @@
-export const getAnthropicApiKeyError = () => `
-Error: ANTHROPIC_API_KEY environment variable is not set
+// Provider configuration map
+export const providerConfig: Record<
+  string,
+  { keyName: string; docsUrl: string } | undefined
+> = {
+  anthropic: {
+    keyName: 'ANTHROPIC_API_KEY',
+    docsUrl: 'https://mycoder.ai/docs/getting-started/anthropic',
+  },
+  openai: {
+    keyName: 'OPENAI_API_KEY',
+    docsUrl: 'https://mycoder.ai/docs/getting-started/openai',
+  },
+  xai: {
+    keyName: 'XAI_API_KEY',
+    docsUrl: 'https://mycoder.ai/docs/getting-started/xai',
+  },
+  mistral: {
+    keyName: 'MISTRAL_API_KEY',
+    docsUrl: 'https://mycoder.ai/docs/getting-started/mistral',
+  },
+  // No API key needed for ollama as it uses a local server
+  ollama: undefined,
+};
 
-Before using MyCoder with Anthropic models, you must have an ANTHROPIC_API_KEY specified either:
+/**
+ * Generates a provider-specific API key error message
+ * @param provider The LLM provider name
+ * @returns Error message with provider-specific instructions
+ */
+export const getProviderApiKeyError = (provider: string): string => {
+  const config = providerConfig[provider];
 
-- As an environment variable, "export ANTHROPIC_API_KEY=[your-api-key]" or
+  if (!config) {
+    return `Unknown provider: ${provider}`;
+  }
+
+  const { keyName, docsUrl } = config;
+
+  return `
+Error: ${keyName} environment variable is not set
+
+Before using MyCoder with ${provider} models, you must have a ${keyName} specified either:
+
+- As an environment variable, "export ${keyName}=[your-api-key]" or
 - In a .env file in the folder you run "mycoder" from
 
-Get an API key from https://www.anthropic.com/api
-For setup instructions, visit: https://mycoder.ai/docs/getting-started/anthropic
+For setup instructions, visit: ${docsUrl}
 `;
+};
 
-export const getOpenAIApiKeyError = () => `
-Error: OPENAI_API_KEY environment variable is not set
-
-Before using MyCoder with OpenAI models, you must have an OPENAI_API_KEY specified either:
-
-- As an environment variable, "export OPENAI_API_KEY=[your-api-key]" or
-- In a .env file in the folder you run "mycoder" from
-
-Get an API key from https://platform.openai.com/api-keys
-For setup instructions, visit: https://mycoder.ai/docs/getting-started/openai
-`;
-
-export const getXAIApiKeyError = () => `
-Error: XAI_API_KEY environment variable is not set
-
-Before using MyCoder with xAI models, you must have an XAI_API_KEY specified either:
-
-- As an environment variable, "export XAI_API_KEY=[your-api-key]" or
-- In a .env file in the folder you run "mycoder" from
-
-Get an API key from https://platform.xai.com
-For setup instructions, visit: https://mycoder.ai/docs/getting-started/xai
-`;
-
-export const getMistralApiKeyError = () => `
-Error: MISTRAL_API_KEY environment variable is not set
-
-Before using MyCoder with Mistral models, you must have a MISTRAL_API_KEY specified either:
-
-- As an environment variable, "export MISTRAL_API_KEY=[your-api-key]" or
-- In a .env file in the folder you run "mycoder" from
-
-Get an API key from https://console.mistral.ai/api-keys/
-For setup instructions, visit: https://mycoder.ai/docs/getting-started/mistral
-`;
+// Legacy function for backward compatibility
+export const getAnthropicApiKeyError = () =>
+  getProviderApiKeyError('anthropic');

--- a/packages/agent/src/utils/errors.ts
+++ b/packages/agent/src/utils/errors.ts
@@ -36,13 +36,24 @@ export const getProviderApiKeyError = (provider: string): string => {
   }
 
   const { keyName, docsUrl } = config;
+  const platform = process.platform;
+  let osSpecificInstructions = '';
+
+  if (platform === 'win32') {
+    osSpecificInstructions = `- Using the windows command prompt, "setx ${keyName}=[your-api-key]"`;
+  } else if (platform === 'darwin' || platform === 'linux') {
+    osSpecificInstructions = `- As an environment variable, "export ${keyName}=[your-api-key]"`;
+  } else {
+    osSpecificInstructions = `- As an environment variable (platform-specific command)`;
+  }
 
   return `
 Error: ${keyName} environment variable is not set
 
-Before using MyCoder with ${provider} models, you must have a ${keyName} specified either:
+Before using MyCoder with ${provider} models, you must have a ${keyName} specified.
 
-- As an environment variable, "export ${keyName}=[your-api-key]" or
+You can set it via:
+${osSpecificInstructions}
 - In a .env file in the folder you run "mycoder" from
 
 For setup instructions, visit: ${docsUrl}

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -7,6 +7,9 @@ import {
   Logger,
   getTools,
   getAnthropicApiKeyError,
+  getOpenAIApiKeyError,
+  getXAIApiKeyError,
+  getMistralApiKeyError,
   userPrompt,
   LogLevel,
   subAgentTool,
@@ -102,25 +105,16 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         userModelProvider === 'openai' &&
         !process.env.OPENAI_API_KEY
       ) {
-        logger.error(
-          'No OpenAI API key found. Please set the OPENAI_API_KEY environment variable.',
-          'You can get an API key from https://platform.openai.com/api-keys',
-        );
+        logger.error(getOpenAIApiKeyError());
         throw new Error('OpenAI API key not found');
       } else if (userModelProvider === 'xai' && !process.env.XAI_API_KEY) {
-        logger.error(
-          'No xAI API key found. Please set the XAI_API_KEY environment variable.',
-          'You can get an API key from https://platform.xai.com',
-        );
+        logger.error(getXAIApiKeyError());
         throw new Error('xAI API key not found');
       } else if (
         userModelProvider === 'mistral' &&
         !process.env.MISTRAL_API_KEY
       ) {
-        logger.error(
-          'No Mistral API key found. Please set the MISTRAL_API_KEY environment variable.',
-          'You can get an API key from https://console.mistral.ai/api-keys/',
-        );
+        logger.error(getMistralApiKeyError());
         throw new Error('Mistral API key not found');
       }
       // No API key check needed for Ollama as it uses a local server

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -6,10 +6,8 @@ import {
   toolAgent,
   Logger,
   getTools,
-  getAnthropicApiKeyError,
-  getOpenAIApiKeyError,
-  getXAIApiKeyError,
-  getMistralApiKeyError,
+  getProviderApiKeyError,
+  providerConfig,
   userPrompt,
   LogLevel,
   subAgentTool,
@@ -98,24 +96,17 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
       const userModelName = argv.modelName || userConfig.modelName;
 
       // Early API key check based on model provider
-      if (userModelProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
-        logger.error(getAnthropicApiKeyError());
-        throw new Error('Anthropic API key not found');
-      } else if (
-        userModelProvider === 'openai' &&
-        !process.env.OPENAI_API_KEY
-      ) {
-        logger.error(getOpenAIApiKeyError());
-        throw new Error('OpenAI API key not found');
-      } else if (userModelProvider === 'xai' && !process.env.XAI_API_KEY) {
-        logger.error(getXAIApiKeyError());
-        throw new Error('xAI API key not found');
-      } else if (
-        userModelProvider === 'mistral' &&
-        !process.env.MISTRAL_API_KEY
-      ) {
-        logger.error(getMistralApiKeyError());
-        throw new Error('Mistral API key not found');
+      const providerSettings =
+        providerConfig[userModelProvider as keyof typeof providerConfig];
+
+      if (providerSettings) {
+        const { keyName } = providerSettings;
+        const apiKey = process.env[keyName];
+
+        if (!apiKey) {
+          logger.error(getProviderApiKeyError(userModelProvider));
+          throw new Error(`${userModelProvider} API key not found`);
+        }
       }
       // No API key check needed for Ollama as it uses a local server
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the CLI tool would throw an error about the Anthropic API key not being set, even when using other LLM providers. The issue was caused by a hardcoded check for the Anthropic API key in the tool agent implementation that ran regardless of which provider was configured.

## Changes
1. Removed the hardcoded Anthropic API key check from `toolAgentCore.ts`
2. Created a provider configuration map with API key names and documentation URLs
3. Implemented a generic `getProviderApiKeyError` function that generates provider-specific error messages
4. Updated the CLI command to use the provider config map for API key validation
5. Maintained backward compatibility by keeping the `getAnthropicApiKeyError` function

## Benefits of the Approach
- **Maintainability**: Adding a new provider only requires adding an entry to the provider config map
- **Consistency**: All provider error messages follow the same format
- **Flexibility**: Provider-specific settings (key name, docs URL) are centralized
- **Simplicity**: Reduced code duplication and simplified API key validation logic

## Testing
- Built the project successfully with `pnpm build`
- The CLI will now only check for the API key of the currently selected LLM provider
- Error messages include links to provider-specific documentation

## Related Issues
Fixes #115