### PR TITLE
Add tokenCache configuration option

### DIFF
--- a/.changeset/itchy-hounds-cross.md
+++ b/.changeset/itchy-hounds-cross.md
@@ -1,0 +1,6 @@
+---
+'mycoder-agent': patch
+'mycoder': patch
+---
+
+Add ability to enable/disable token caching via config values

--- a/packages/agent/src/core/tokens.ts
+++ b/packages/agent/src/core/tokens.ts
@@ -73,6 +73,7 @@ export class TokenUsage {
 export class TokenTracker {
   public tokenUsage = new TokenUsage();
   public children: TokenTracker[] = [];
+  public tokenCache?: boolean;
 
   constructor(
     public readonly name: string = 'unnamed',

--- a/packages/agent/src/core/toolAgent/toolAgentCore.ts
+++ b/packages/agent/src/core/toolAgent/toolAgentCore.ts
@@ -64,7 +64,13 @@ export const toolAgent = async (
             createCacheControlMessageFromSystemPrompt(systemPrompt),
             ...addCacheControlToMessages(messages),
           ]
-        : [{ role: 'system', content: systemPrompt }, ...messages];
+        : [
+            {
+              role: 'system',
+              content: systemPrompt,
+            } as CoreMessage,
+            ...messages,
+          ];
 
     const generateTextProps = {
       model: config.model,

--- a/packages/agent/src/core/toolAgent/toolAgentCore.ts
+++ b/packages/agent/src/core/toolAgent/toolAgentCore.ts
@@ -57,11 +57,14 @@ export const toolAgent = async (
       });
     });
 
-    // Apply cache control to messages for token caching
-    const messagesWithCacheControl = [
-      createCacheControlMessageFromSystemPrompt(systemPrompt),
-      ...addCacheControlToMessages(messages),
-    ];
+    // Apply cache control to messages for token caching if enabled
+    const messagesWithCacheControl =
+      tokenTracker.tokenCache !== false && context.tokenCache !== false
+        ? [
+            createCacheControlMessageFromSystemPrompt(systemPrompt),
+            ...addCacheControlToMessages(messages),
+          ]
+        : [{ role: 'system', content: systemPrompt }, ...messages];
 
     const generateTextProps = {
       model: config.model,

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -18,6 +18,7 @@ export type ToolContext = {
   tokenTracker: TokenTracker;
   githubMode: boolean;
   customPrompt?: string;
+  tokenCache?: boolean;
 };
 
 export type Tool<TParams = Record<string, any>, TReturn = any> = {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,6 +125,7 @@ mycoder --modelProvider openai --modelName gpt-4o-2024-05-13 "Your prompt here"
 - `pageFilter`: Method to process webpage content: 'simple', 'none', or 'readability' (default: `none`)
 - `ollamaBaseUrl`: Base URL for Ollama API (default: `http://localhost:11434/api`)
 - `customPrompt`: Custom instructions to append to the system prompt for both main agent and sub-agents (default: `""`)
+- `tokenCache`: Enable token caching for LLM API calls (default: `true`)
 
 Example:
 
@@ -143,6 +144,9 @@ mycoder config set ollamaBaseUrl http://your-ollama-server:11434/api
 
 # Set custom instructions for the agent
 mycoder config set customPrompt "Always prioritize readability and simplicity in your code. Prefer TypeScript over JavaScript when possible."
+
+# Disable token caching for LLM API calls
+mycoder config set tokenCache false
 ```
 
 ## Environment Variables

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -88,13 +88,14 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
       undefined,
       argv.tokenUsage ? LogLevel.info : LogLevel.debug,
     );
-    // Use command line option if provided, otherwise use config value
-    tokenTracker.tokenCache =
-      argv.tokenCache !== undefined ? argv.tokenCache : userConfig.tokenCache;
 
     try {
       // Get configuration for model provider and name
       const userConfig = getConfig();
+      // Use command line option if provided, otherwise use config value
+      tokenTracker.tokenCache =
+        argv.tokenCache !== undefined ? argv.tokenCache : userConfig.tokenCache;
+
       const userModelProvider = argv.modelProvider || userConfig.modelProvider;
       const userModelName = argv.modelName || userConfig.modelName;
 

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -88,6 +88,9 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
       undefined,
       argv.tokenUsage ? LogLevel.info : LogLevel.debug,
     );
+    // Use command line option if provided, otherwise use config value
+    tokenTracker.tokenCache =
+      argv.tokenCache !== undefined ? argv.tokenCache : userConfig.tokenCache;
 
     try {
       // Get configuration for model provider and name
@@ -177,6 +180,8 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         tokenTracker,
         githubMode: config.githubMode,
         customPrompt: config.customPrompt,
+        tokenCache:
+          argv.tokenCache !== undefined ? argv.tokenCache : config.tokenCache,
       });
 
       const output =

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -10,6 +10,7 @@ export type SharedOptions = {
   readonly modelProvider?: string;
   readonly modelName?: string;
   readonly profile?: boolean;
+  readonly tokenCache?: boolean;
 };
 
 export const sharedOptions = {
@@ -71,5 +72,9 @@ export const sharedOptions = {
     type: 'string',
     description: 'Custom Sentry DSN for error tracking',
     hidden: true,
+  } as const,
+  tokenCache: {
+    type: 'boolean',
+    description: 'Enable token caching for LLM API calls',
   } as const,
 };

--- a/packages/cli/src/settings/config.ts
+++ b/packages/cli/src/settings/config.ts
@@ -17,6 +17,7 @@ const defaultConfig = {
   ollamaBaseUrl: 'http://localhost:11434/api',
   customPrompt: '',
   profile: false,
+  tokenCache: true,
 };
 
 export type Config = typeof defaultConfig;

--- a/packages/cli/tests/settings/config.test.ts
+++ b/packages/cli/tests/settings/config.test.ts
@@ -46,6 +46,7 @@ describe('Config', () => {
         ollamaBaseUrl: 'http://localhost:11434/api',
         profile: false,
         customPrompt: '',
+        tokenCache: true,
       });
       expect(fs.existsSync).toHaveBeenCalledWith(mockConfigFile);
     });
@@ -80,6 +81,7 @@ describe('Config', () => {
         ollamaBaseUrl: 'http://localhost:11434/api',
         profile: false,
         customPrompt: '',
+        tokenCache: true,
       });
     });
   });


### PR DESCRIPTION
# Add tokenCache configuration option

## Description
This PR adds a new configuration option called `tokenCache` to control whether token caching is enabled in API calls. The default value is `true` to maintain current behavior.

When set to `false`, the CLI bypasses adding cache-control metadata to messages when calling the LLM API.

## Changes
- Added `tokenCache: boolean` to the configuration schema with a default value of `true`
- Modified the `ToolContext` type to include the `tokenCache` option
- Added the `tokenCache` property to the `TokenTracker` class
- Modified `toolAgentCore.ts` to conditionally apply cache control based on this setting
- Added a command-line option for `tokenCache`
- Updated the README to document the new option

## Testing
The implementation has been tested by:
- Setting the configuration via `mycoder config set tokenCache false`
- Verifying that the option is correctly passed to the agent
- Confirming that when disabled, cache control metadata is not added to messages

## Related Issues
Fixes #119