### PR TITLE
Add build and test checks to pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,24 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running pre-commit checks..."
+
+# Run lint-staged for code formatting and linting
+echo "Running lint-staged..."
 pnpm lint-staged
+
+# Run build to ensure project builds successfully
+echo "Running build checks..."
+pnpm build || {
+  echo "❌ Build failed. Please fix the build errors before committing."
+  exit 1
+}
+
+# Run tests to ensure all tests pass
+echo "Running tests..."
+pnpm test || {
+  echo "❌ Tests failed. Please fix the failing tests before committing."
+  exit 1
+}
+
+echo "✅ All checks passed!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,10 @@ This project and everyone participating in it is governed by our Code of Conduct
 
    - `pnpm lint`: Lints the staged files using ESLint
    - `pnpm format`: Formats the staged files using Prettier
+   - `pnpm build`: Ensures the project builds successfully
+   - `pnpm test`: Ensures all tests pass
 
-   If either of these commands fails due to linting errors or formatting issues, the commit will be aborted. Please fix the reported issues and try committing again.
+   If any of these commands fails, the commit will be aborted. Please fix the reported issues and try committing again.
 
    You can also run the lint and format commands manually at any time:
 


### PR DESCRIPTION
## Description

This PR enhances the pre-commit hooks to include build and test checks, preventing commits that would break the build or fail tests.

## Changes

- Updated the pre-commit hook to run `pnpm build` and `pnpm test` before allowing commits
- Updated the CONTRIBUTING.md documentation to reflect these changes

## Testing

- Tested the pre-commit hook locally to ensure it correctly prevents commits when builds fail or tests don't pass
- Confirmed that the hook allows commits when all checks pass

## Related Issues

Fixes #122

## Note

There's a Husky deprecation warning about the shebang and source line that will need to be addressed in a future update when upgrading to Husky v10.0.0.