### PR TITLE
Add ability to store API keys in configuration

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -45,6 +45,10 @@ export const command: CommandModule<SharedOptions, ConfigOptions> = {
       .example(
         '$0 config clear customPrompt',
         'Reset customPrompt to default value',
+      )
+      .example(
+        '$0 config set ANTHROPIC_API_KEY <your-key>',
+        'Store your Anthropic API key in configuration',
       ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
   },
   handler: async (argv: ArgumentsCamelCase<ConfigOptions>) => {
@@ -118,6 +122,30 @@ export const command: CommandModule<SharedOptions, ConfigOptions> = {
           `Valid configuration keys: ${Object.keys(defaultConfig).join(', ')}`,
         );
         return;
+      }
+
+      // Check if this is an API key and add a warning
+      if (argv.key.includes('API_KEY')) {
+        logger.warn(
+          chalk.yellow(
+            'Warning: Storing API keys in configuration is less secure than using environment variables.'
+          )
+        );
+        logger.warn(
+          chalk.yellow(
+            'Your API key will be stored in plaintext in the configuration file.'
+          )
+        );
+        
+        // Ask for confirmation
+        const isConfirmed = await confirm(
+          'Do you want to continue storing your API key in the configuration?'
+        );
+        
+        if (!isConfirmed) {
+          logger.info('Operation cancelled.');
+          return;
+        }
       }
 
       // Parse the value based on current type or infer boolean/number

--- a/packages/cli/src/settings/config.ts
+++ b/packages/cli/src/settings/config.ts
@@ -20,6 +20,11 @@ const defaultConfig = {
   customPrompt: '',
   profile: false,
   tokenCache: true,
+  // API keys (empty by default)
+  ANTHROPIC_API_KEY: '',
+  OPENAI_API_KEY: '',
+  XAI_API_KEY: '',
+  MISTRAL_API_KEY: '',
 };
 
 export type Config = typeof defaultConfig;

--- a/packages/cli/tests/settings/config.test.ts
+++ b/packages/cli/tests/settings/config.test.ts
@@ -49,6 +49,11 @@ describe('Config', () => {
         profile: false,
         customPrompt: '',
         tokenCache: true,
+        // API keys
+        ANTHROPIC_API_KEY: '',
+        OPENAI_API_KEY: '',
+        XAI_API_KEY: '',
+        MISTRAL_API_KEY: '',
       });
       expect(fs.existsSync).toHaveBeenCalledWith(mockConfigFile);
     });
@@ -86,6 +91,11 @@ describe('Config', () => {
         profile: false,
         customPrompt: '',
         tokenCache: true,
+        // API keys
+        ANTHROPIC_API_KEY: '',
+        OPENAI_API_KEY: '',
+        XAI_API_KEY: '',
+        MISTRAL_API_KEY: '',
       });
     });
   });


### PR DESCRIPTION
# Add ability to store API keys in configuration

## Description
This PR implements the functionality requested in issue #134, allowing users to store API keys in the configuration file as an alternative to setting environment variables.

## Changes
- Added API key fields to the default configuration in `config.ts`
- Updated the API key retrieval logic in `$default.ts` to check both the config file and environment variables
- Added special handling for API keys in the config command with security warnings and confirmation
- Added example to the help text for setting API keys

## Security Considerations
- Added warnings about the security implications of storing API keys in plaintext
- Added a confirmation prompt before storing API keys
- Environment variables still take precedence over stored configuration

## Testing
- Manually tested setting and using API keys from configuration
- Verified that the confirmation prompt works correctly
- Confirmed that environment variables take precedence when both are set

## Related Issues
Fixes #134