### PR TITLE
Add GitHub Action for issue comment commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         run: cd packages/agent && pnpm exec playwright install --with-deps chromium
 
       - name: Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: pnpm test
 
       - name: Lint

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -31,29 +31,25 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
-      - name: Install MyCoder
-        run: pnpm install -g mycoder
+      - name: Install MyCoder globally
+        run: |
+          # Skip tests when installing globally
+          pnpm install -g mycoder --no-frozen-lockfile --ignore-scripts
 
       - name: Run MyCoder PR command
         if: contains(github.event.comment.body, '/mycoder pr')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         run: |
           echo "Running MyCoder to implement PR for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true "Implement a PR for GitHub issue #${{ github.event.issue.number }}. The issue can be found at ${{ github.event.issue.html_url }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
+          mycoder --githubMode true "Implement a PR for GitHub issue #${{ github.event.issue.number }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
 
       - name: Run MyCoder Plan command
         if: contains(github.event.comment.body, '/mycoder plan')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         run: |
           echo "Running MyCoder to create implementation plan for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true "Review GitHub issue #${{ github.event.issue.number }} at ${{ github.event.issue.html_url }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."
+          mycoder --githubMode true "Review GitHub issue #${{ github.event.issue.number }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -1,0 +1,59 @@
+name: MyCoder Issue Comment Action
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+env:
+  PNPM_VERSION: 10.2.1
+
+jobs:
+  process-comment:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/mycoder pr') || contains(github.event.comment.body, '/mycoder plan')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install MyCoder
+        run: pnpm install -g mycoder
+
+      - name: Run MyCoder PR command
+        if: contains(github.event.comment.body, '/mycoder pr')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        run: |
+          echo "Running MyCoder to implement PR for issue #${{ github.event.issue.number }}"
+          mycoder --githubMode true "Implement a PR for GitHub issue #${{ github.event.issue.number }}. The issue can be found at ${{ github.event.issue.html_url }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
+
+      - name: Run MyCoder Plan command
+        if: contains(github.event.comment.body, '/mycoder plan')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        run: |
+          echo "Running MyCoder to create implementation plan for issue #${{ github.event.issue.number }}"
+          mycoder --githubMode true "Review GitHub issue #${{ github.event.issue.number }} at ${{ github.event.issue.html_url }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -15,8 +15,25 @@ env:
 jobs:
   process-comment:
     runs-on: ubuntu-latest
-    if: contains(github.event.comment.body, '/mycoder pr') || contains(github.event.comment.body, '/mycoder plan')
+    if: contains(github.event.comment.body, '/mycoder')
     steps:
+      - name: Extract prompt from comment
+        id: extract-prompt
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          if [[ "$COMMENT" =~ "/mycoder "(.+) ]]; then
+            PROMPT="${BASH_REMATCH[1]}"
+          elif [[ "$COMMENT" =~ "/mycoder" ]]; then
+            # If just /mycoder with no text after, use a default prompt
+            PROMPT="Please review this issue and suggest next steps."
+          else
+            echo "No valid /mycoder command found"
+            exit 1
+          fi
+          echo "prompt=$PROMPT" >> $GITHUB_OUTPUT
+          echo "comment_url=${{ github.event.comment.html_url }}" >> $GITHUB_OUTPUT
+          echo "comment_id=${{ github.event.comment.id }}" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -36,20 +53,10 @@ jobs:
           # Skip tests when installing globally
           pnpm install -g mycoder --no-frozen-lockfile --ignore-scripts
 
-      - name: Run MyCoder PR command
-        if: contains(github.event.comment.body, '/mycoder pr')
+      - name: Run MyCoder with prompt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          echo "Running MyCoder to implement PR for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true --userPrompt false "Implement a PR for GitHub issue #${{ github.event.issue.number }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
-
-      - name: Run MyCoder Plan command
-        if: contains(github.event.comment.body, '/mycoder plan')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          echo "Running MyCoder to create implementation plan for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true --userPrompt false "Review GitHub issue #${{ github.event.issue.number }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."
+          echo "Running MyCoder for issue #${{ github.event.issue.number }} with prompt: ${{ steps.extract-prompt.outputs.prompt }}"
+          mycoder --githubMode true --userPrompt false "On issue #${{ github.event.issue.number }} the user asked: '${{ steps.extract-prompt.outputs.prompt }}' in comment ${{ steps.extract-prompt.outputs.comment_url }}. Please address this request. If you create a PR or take actions outside the scope of this issue, please report back to the issue with a comment explaining what you did."

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -43,7 +43,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           echo "Running MyCoder to implement PR for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true "Implement a PR for GitHub issue #${{ github.event.issue.number }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
+          mycoder --githubMode true --userPrompt false "Implement a PR for GitHub issue #${{ github.event.issue.number }}. Please review the issue details and implement a solution according to the requirements. After implementation, create a pull request that addresses this issue."
 
       - name: Run MyCoder Plan command
         if: contains(github.event.comment.body, '/mycoder plan')
@@ -52,4 +52,4 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           echo "Running MyCoder to create implementation plan for issue #${{ github.event.issue.number }}"
-          mycoder --githubMode true "Review GitHub issue #${{ github.event.issue.number }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."
+          mycoder --githubMode true --userPrompt false "Review GitHub issue #${{ github.event.issue.number }} and create an implementation plan. Post your plan as a comment on the issue. Be thorough and consider all requirements mentioned in the issue description."

--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ mycoder config set githubMode true
 
 ### GitHub Comment Commands
 
-MyCoder can be triggered directly from GitHub issue comments using special commands:
+MyCoder can be triggered directly from GitHub issue comments using the flexible `/mycoder` command:
 
-- `/mycoder pr` - Implements a PR for the given issue
-- `/mycoder plan` - Generates an implementation plan as a comment
+```
+/mycoder [your instructions here]
+```
+
+Examples:
+- `/mycoder implement a PR for this issue`
+- `/mycoder create an implementation plan`
+- `/mycoder suggest test cases for this feature`
 
 [Learn more about GitHub comment commands](docs/github-comment-commands.md)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ mycoder -f prompt.txt
 mycoder config set githubMode true
 ```
 
+### GitHub Comment Commands
+
+MyCoder can be triggered directly from GitHub issue comments using special commands:
+
+- `/mycoder pr` - Implements a PR for the given issue
+- `/mycoder plan` - Generates an implementation plan as a comment
+
+[Learn more about GitHub comment commands](docs/github-comment-commands.md)
+
 ## Packages
 
 - [mycoder](packages/cli) - Command-line interface for MyCoder

--- a/docs/github-comment-commands.md
+++ b/docs/github-comment-commands.md
@@ -1,43 +1,68 @@
 # GitHub Comment Commands
 
-MyCoder provides automated actions in response to specific commands in GitHub issue comments. This feature allows you to trigger MyCoder directly from GitHub issues.
+MyCoder provides automated actions in response to `/mycoder` commands in GitHub issue comments. This feature allows you to trigger MyCoder directly from GitHub issues with flexible prompts.
 
-## Available Commands
+## How to Use
 
-### `/mycoder pr`
+Simply add a comment to any GitHub issue with `/mycoder` followed by your instructions:
 
-When you add a comment with `/mycoder pr` to any issue, MyCoder will:
+```
+/mycoder [your instructions here]
+```
 
+MyCoder will process your instructions in the context of the issue and respond accordingly.
+
+## Examples
+
+### Creating a PR
+
+```
+/mycoder implement a PR for this issue
+```
+
+MyCoder will:
 1. Check out the repository
 2. Review the issue details
 3. Implement a solution according to the requirements
 4. Create a pull request that addresses the issue
 
-Example:
+### Creating an Implementation Plan
+
 ```
-This looks like a great feature to add!
-
-/mycoder pr
+/mycoder create an implementation plan for this issue
 ```
 
-### `/mycoder plan`
-
-When you add a comment with `/mycoder plan` to any issue, MyCoder will:
-
+MyCoder will:
 1. Review the issue details
 2. Create a comprehensive implementation plan
 3. Post the plan as a comment on the issue
 
-Example:
-```
-I'm not sure about the best approach for this.
+### Other Use Cases
 
-/mycoder plan
+The `/mycoder` command is flexible and can handle various requests:
+
+```
+/mycoder suggest test cases for this feature
+```
+
+```
+/mycoder analyze the performance implications of this change
+```
+
+```
+/mycoder recommend libraries we could use for this implementation
 ```
 
 ## How It Works
 
-This functionality is implemented as a GitHub Action that runs whenever a new comment is added to an issue. The action checks for these specific command patterns and triggers MyCoder with the appropriate instructions.
+This functionality is implemented as a GitHub Action that runs whenever a new comment is added to an issue. The action checks for the `/mycoder` command pattern and triggers MyCoder with the appropriate instructions.
+
+MyCoder receives context about:
+- The issue number
+- The specific prompt you provided
+- The comment URL where the command was triggered
+
+If MyCoder creates a PR or takes actions outside the scope of the issue, it will report back to the issue with a comment explaining what was done.
 
 ## Requirements
 
@@ -52,4 +77,4 @@ For this feature to work in your repository:
 
 - The action runs with GitHub's default timeout limits
 - Complex implementations may require multiple iterations
-- The AI model's capabilities determine the quality of the implementation or plan
+- The AI model's capabilities determine the quality of the results

--- a/docs/github-comment-commands.md
+++ b/docs/github-comment-commands.md
@@ -1,0 +1,55 @@
+# GitHub Comment Commands
+
+MyCoder provides automated actions in response to specific commands in GitHub issue comments. This feature allows you to trigger MyCoder directly from GitHub issues.
+
+## Available Commands
+
+### `/mycoder pr`
+
+When you add a comment with `/mycoder pr` to any issue, MyCoder will:
+
+1. Check out the repository
+2. Review the issue details
+3. Implement a solution according to the requirements
+4. Create a pull request that addresses the issue
+
+Example:
+```
+This looks like a great feature to add!
+
+/mycoder pr
+```
+
+### `/mycoder plan`
+
+When you add a comment with `/mycoder plan` to any issue, MyCoder will:
+
+1. Review the issue details
+2. Create a comprehensive implementation plan
+3. Post the plan as a comment on the issue
+
+Example:
+```
+I'm not sure about the best approach for this.
+
+/mycoder plan
+```
+
+## How It Works
+
+This functionality is implemented as a GitHub Action that runs whenever a new comment is added to an issue. The action checks for these specific command patterns and triggers MyCoder with the appropriate instructions.
+
+## Requirements
+
+For this feature to work in your repository:
+
+1. The GitHub Action workflow must be present in your repository
+2. You need to configure the necessary API keys as GitHub secrets:
+   - `GITHUB_TOKEN` (automatically provided)
+   - `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, or `MISTRAL_API_KEY` (depending on your preferred model)
+
+## Limitations
+
+- The action runs with GitHub's default timeout limits
+- Complex implementations may require multiple iterations
+- The AI model's capabilities determine the quality of the implementation or plan


### PR DESCRIPTION
## Description

This PR adds a GitHub Action that responds to specific commands in GitHub issue comments:

- `/mycoder pr` - Implements a PR for the given issue
- `/mycoder plan` - Generates an implementation plan as a comment

## Implementation Details

The GitHub Action:
- Triggers on each new comment on any GitHub issue
- Checks for specific command patterns in the comment
- For `/mycoder pr`:
  - Checks out the repository
  - Sets up Node.js
  - Installs MyCoder via `pnpm install -g mycoder`
  - Runs MyCoder with `--githubMode true` to implement a PR for the issue
- For `/mycoder plan`:
  - Similar setup, but instructs MyCoder to review the issue and submit an implementation plan

## Documentation

- Added a new documentation file `docs/github-comment-commands.md` with detailed information
- Updated the README.md to mention this new feature

## Testing

This PR implements the functionality for both commands as described in issue #162. After this PR is merged, we can test it in real-world scenarios and make any necessary refinements.

Closes #162