### PR TITLE
Add enableUserPrompt command line option

### DIFF
--- a/.changeset/enable-user-prompt-option.md
+++ b/.changeset/enable-user-prompt-option.md
@@ -1,0 +1,6 @@
+---
+'mycoder': patch
+'mycoder-agent': patch
+---
+
+Add `--enableUserPrompt` command line option that defaults to true but can be set to false to disable the userPrompt tool for fully automated sessions.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ mycoder "Implement a React component that displays a list of items"
 # Run with a prompt from a file
 mycoder -f prompt.txt
 
+# Disable user prompts for fully automated sessions
+mycoder --enableUserPrompt false "Generate a basic Express.js server"
+
 # Enable GitHub mode
 mycoder config set githubMode true
 ```

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -19,6 +19,7 @@ export type ToolContext = {
   githubMode: boolean;
   customPrompt?: string;
   tokenCache?: boolean;
+  enableUserPrompt?: boolean;
 };
 
 export type Tool<TParams = Record<string, any>, TReturn = any> = {

--- a/packages/agent/src/tools/getTools.ts
+++ b/packages/agent/src/tools/getTools.ts
@@ -1,5 +1,6 @@
 import { Tool } from '../core/types.js';
 
+// Import tools
 import { browseMessageTool } from './browser/browseMessage.js';
 import { browseStartTool } from './browser/browseStart.js';
 import { subAgentTool } from './interaction/subAgent.js';
@@ -12,18 +13,33 @@ import { shellMessageTool } from './system/shellMessage.js';
 import { shellStartTool } from './system/shellStart.js';
 import { sleepTool } from './system/sleep.js';
 
-export function getTools(): Tool[] {
-  return [
-    textEditorTool,
-    subAgentTool,
-    userPromptTool,
-    sequenceCompleteTool,
-    fetchTool,
-    shellStartTool,
-    shellMessageTool,
-    browseStartTool,
-    browseMessageTool,
-    respawnTool,
-    sleepTool,
-  ] as Tool[];
+// Import these separately to avoid circular dependencies
+
+interface GetToolsOptions {
+  enableUserPrompt?: boolean;
+}
+
+export function getTools(options?: GetToolsOptions): Tool[] {
+  const enableUserPrompt = options?.enableUserPrompt !== false; // Default to true if not specified
+
+  // Force cast to Tool type to avoid TypeScript issues
+  const tools: Tool[] = [
+    textEditorTool as unknown as Tool,
+    subAgentTool as unknown as Tool,
+    sequenceCompleteTool as unknown as Tool,
+    fetchTool as unknown as Tool,
+    shellStartTool as unknown as Tool,
+    shellMessageTool as unknown as Tool,
+    browseStartTool as unknown as Tool,
+    browseMessageTool as unknown as Tool,
+    respawnTool as unknown as Tool,
+    sleepTool as unknown as Tool,
+  ];
+
+  // Only include userPrompt tool if enabled
+  if (enableUserPrompt) {
+    tools.push(userPromptTool as unknown as Tool);
+  }
+
+  return tools;
 }

--- a/packages/agent/src/tools/interaction/subAgent.ts
+++ b/packages/agent/src/tools/interaction/subAgent.ts
@@ -90,7 +90,7 @@ export const subAgentTool: Tool<Parameters, ReturnType> = {
       .filter(Boolean)
       .join('\n');
 
-    const tools = getTools().filter((tool) => tool.name !== 'userPrompt');
+    const tools = getTools({ enableUserPrompt: false });
 
     // Update config if timeout is specified
     const config = {

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -162,7 +162,10 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         'Once the task is complete ask the user, via the userPrompt tool if the results are acceptable or if changes are needed or if there are additional follow on tasks.',
       ].join('\n');
 
-      const tools = getTools();
+      const tools = getTools({
+        enableUserPrompt:
+          argv.enableUserPrompt !== undefined ? argv.enableUserPrompt : true,
+      });
 
       // Error handling
       process.on('SIGINT', () => {
@@ -202,6 +205,8 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         customPrompt: config.customPrompt,
         tokenCache:
           argv.tokenCache !== undefined ? argv.tokenCache : config.tokenCache,
+        enableUserPrompt:
+          argv.enableUserPrompt !== undefined ? argv.enableUserPrompt : true,
       });
 
       const output =

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -13,6 +13,7 @@ export type SharedOptions = {
   readonly temperature?: number;
   readonly profile?: boolean;
   readonly tokenCache?: boolean;
+  readonly enableUserPrompt?: boolean;
 };
 
 export const sharedOptions = {
@@ -86,5 +87,11 @@ export const sharedOptions = {
   tokenCache: {
     type: 'boolean',
     description: 'Enable token caching for LLM API calls',
+  } as const,
+  enableUserPrompt: {
+    type: 'boolean',
+    description:
+      'Enable or disable the userPrompt tool (disable for fully automated sessions)',
+    default: true,
   } as const,
 };


### PR DESCRIPTION
## Add enableUserPrompt command line option

This PR adds a new command line option `--enableUserPrompt` that defaults to true but can be set to false to disable the userPrompt tool for fully automated sessions.

### Changes
- Added `enableUserPrompt` option to the shared options in CLI package
- Modified getTools function to conditionally include userPrompt tool based on this setting
- Updated ToolContext type to include enableUserPrompt option
- Updated subAgent to use the new getTools API
- Updated README.md to document the new option
- Added changeset file for patch version bump

### Testing
- All existing tests pass
- Manually verified that the userPrompt tool is disabled when `--enableUserPrompt false` is used

Fixes #164