### PR TITLE
feat: add --githubMode and --userPrompt as boolean CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ mycoder -f prompt.txt
 
 # Disable user prompts for fully automated sessions
 mycoder --enableUserPrompt false "Generate a basic Express.js server"
+# or using the alias
+mycoder --userPrompt false "Generate a basic Express.js server"
 
-# Enable GitHub mode
+# Enable GitHub mode via CLI option (overrides config)
+mycoder --githubMode "Work with GitHub issues and PRs"
+
+# Enable GitHub mode via config
 mycoder config set githubMode true
 ```
 

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -172,7 +172,11 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
 
       const tools = getTools({
         enableUserPrompt:
-          argv.enableUserPrompt !== undefined ? argv.enableUserPrompt : true,
+          argv.userPrompt !== undefined
+            ? argv.userPrompt
+            : argv.enableUserPrompt !== undefined
+              ? argv.enableUserPrompt
+              : true,
       });
 
       // Error handling
@@ -209,12 +213,16 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         pageFilter: argv.pageFilter ?? config.pageFilter,
         workingDirectory: '.',
         tokenTracker,
-        githubMode: config.githubMode,
+        githubMode: argv.githubMode ?? config.githubMode,
         customPrompt: config.customPrompt,
         tokenCache:
           argv.tokenCache !== undefined ? argv.tokenCache : config.tokenCache,
         enableUserPrompt:
-          argv.enableUserPrompt !== undefined ? argv.enableUserPrompt : true,
+          argv.userPrompt !== undefined
+            ? argv.userPrompt
+            : argv.enableUserPrompt !== undefined
+              ? argv.enableUserPrompt
+              : true,
       });
 
       const output =

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -17,6 +17,8 @@ export type SharedOptions = {
   readonly profile?: boolean;
   readonly tokenCache?: boolean;
   readonly enableUserPrompt?: boolean;
+  readonly userPrompt?: boolean;
+  readonly githubMode?: boolean;
 };
 
 export const sharedOptions = {
@@ -108,5 +110,16 @@ export const sharedOptions = {
     description:
       'Enable or disable the userPrompt tool (disable for fully automated sessions)',
     default: true,
+  } as const,
+  userPrompt: {
+    type: 'boolean',
+    description:
+      'Alias for enableUserPrompt: enable or disable the userPrompt tool',
+    default: true,
+  } as const,
+  githubMode: {
+    type: 'boolean',
+    description: 'Enable GitHub mode for working with issues and PRs',
+    default: false,
   } as const,
 };


### PR DESCRIPTION
## Description
This PR adds `--githubMode` and `--userPrompt` as boolean command line options that override any config settings or defaults. These CLI options are required for our GitHub Action integration to work properly.

## Changes Made
1. Added `githubMode` to the `SharedOptions` type and `sharedOptions` object in `options.ts`
2. Added `userPrompt` as an alias for `enableUserPrompt` in `options.ts`
3. Updated the default command handler to properly use these CLI options to override config values:
   - Now checking for `argv.githubMode` before falling back to `config.githubMode`
   - Now checking for `argv.userPrompt` before falling back to `argv.enableUserPrompt`
4. Updated README.md to document the new CLI options

## Testing
- All existing tests pass
- Manually verified that the CLI options work as expected

## Related Issues
Closes #168