### PR TITLE
feat: add CLI options for automated usage scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,19 @@
 # [0.8.0](https://github.com/drivecore/mycoder/compare/v0.7.0...v0.8.0) (2025-03-11)
 
-
 ### Features
 
-* add --githubMode and --userPrompt as boolean CLI options that override config settings ([0390f94](https://github.com/drivecore/mycoder/commit/0390f94651e40de93a8cb9486a056a0b9cb2e165))
-* remove modelProvider and modelName - instant decrepation ([59834dc](https://github.com/drivecore/mycoder/commit/59834dcf932051a5c75624bd6f6ab12254f43769))
+- add --githubMode and --userPrompt as boolean CLI options that override config settings ([0390f94](https://github.com/drivecore/mycoder/commit/0390f94651e40de93a8cb9486a056a0b9cb2e165))
+- remove modelProvider and modelName - instant decrepation ([59834dc](https://github.com/drivecore/mycoder/commit/59834dcf932051a5c75624bd6f6ab12254f43769))
 
 # [0.7.0](https://github.com/drivecore/mycoder/compare/v0.6.1...v0.7.0) (2025-03-10)
 
-
 ### Bug Fixes
 
-* change where anthropic key is declared ([f6f72d3](https://github.com/drivecore/mycoder/commit/f6f72d3bc18a65fc775151cd375398aba230a06f))
-* ensure npm publish only happens on release branch ([ec352d6](https://github.com/drivecore/mycoder/commit/ec352d6956c717726ef388a07d88372c12b634a6))
-
+- change where anthropic key is declared ([f6f72d3](https://github.com/drivecore/mycoder/commit/f6f72d3bc18a65fc775151cd375398aba230a06f))
+- ensure npm publish only happens on release branch ([ec352d6](https://github.com/drivecore/mycoder/commit/ec352d6956c717726ef388a07d88372c12b634a6))
 
 ### Features
 
-* add GitHub Action for issue comment commands ([136950f](https://github.com/drivecore/mycoder/commit/136950f4bd6d14e544bbd415ed313f7842a9b9a2)), closes [#162](https://github.com/drivecore/mycoder/issues/162)
-* allow for generic /mycoder commands ([4b6608e](https://github.com/drivecore/mycoder/commit/4b6608e0b8e5f408eb5f12fe891657a5fb25bdb4))
-* **release:** implement conventional commits approach ([5878dd1](https://github.com/drivecore/mycoder/commit/5878dd1a56004eb8a994d40416d759553b022eb8)), closes [#140](https://github.com/drivecore/mycoder/issues/140)
+- add GitHub Action for issue comment commands ([136950f](https://github.com/drivecore/mycoder/commit/136950f4bd6d14e544bbd415ed313f7842a9b9a2)), closes [#162](https://github.com/drivecore/mycoder/issues/162)
+- allow for generic /mycoder commands ([4b6608e](https://github.com/drivecore/mycoder/commit/4b6608e0b8e5f408eb5f12fe891657a5fb25bdb4))
+- **release:** implement conventional commits approach ([5878dd1](https://github.com/drivecore/mycoder/commit/5878dd1a56004eb8a994d40416d759553b022eb8)), closes [#140](https://github.com/drivecore/mycoder/issues/140)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ mycoder --enableUserPrompt false "Generate a basic Express.js server"
 # or using the alias
 mycoder --userPrompt false "Generate a basic Express.js server"
 
+# Disable user consent warning and version upgrade check for automated environments
+mycoder --userWarning false --upgradeCheck false "Generate a basic Express.js server"
+
 # Enable GitHub mode via CLI option (overrides config)
 mycoder --githubMode "Work with GitHub issues and PRs"
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -32,6 +32,12 @@ mycoder "Implement a React component that displays a list of items"
 # Run with a prompt from a file
 mycoder -f prompt.txt
 
+# Disable user prompts for fully automated sessions
+mycoder --userPrompt false "Generate a basic Express.js server"
+
+# Disable user consent warning and version upgrade check for automated environments
+mycoder --userWarning false --upgradeCheck false "Generate a basic Express.js server"
+
 # Enable GitHub mode
 mycoder config set githubMode true
 ```
@@ -103,6 +109,14 @@ mycoder config set model claude-3-7-sonnet-20250219  # or any other Anthropic mo
 - `pageFilter`: Method to process webpage content: 'simple', 'none', or 'readability' (default: `none`)
 - `customPrompt`: Custom instructions to append to the system prompt for both main agent and sub-agents (default: `""`)
 - `tokenCache`: Enable token caching for LLM API calls (default: `true`)
+
+### CLI-Only Options
+
+These options are available only as command-line parameters and are not stored in the configuration:
+
+- `userWarning`: Disable user consent check for automated/remote usage (default: `true`)
+- `upgradeCheck`: Disable version upgrade check for automated/remote usage (default: `true`)
+- `userPrompt`/`enableUserPrompt`: Enable or disable the userPrompt tool (default: `true`)
 
 Example:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -114,7 +114,7 @@ mycoder config set model claude-3-7-sonnet-20250219  # or any other Anthropic mo
 
 These options are available only as command-line parameters and are not stored in the configuration:
 
-- `userWarning`: Disable user consent check for automated/remote usage (default: `true`)
+- `userWarning`: Skip user consent check for current session without saving consent (default: `true`)
 - `upgradeCheck`: Disable version upgrade check for automated/remote usage (default: `true`)
 - `userPrompt`/`enableUserPrompt`: Enable or disable the userPrompt tool (default: `true`)
 

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -86,9 +86,9 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         throw new Error('User did not consent');
       }
     } else if (!hasUserConsented() && argv.userWarning === false) {
-      // Auto-save consent when userWarning is false
+      // Just skip the consent check without saving consent when userWarning is false
       logger.debug('Skipping user consent check due to --userWarning=false');
-      saveUserConsent();
+      // Note: We don't save consent here, just bypassing the check for this session
     }
 
     const tokenTracker = new TokenTracker(

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -57,9 +57,13 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
       `MyCoder v${packageInfo.version} - AI-powered coding assistant`,
     );
 
-    await checkForUpdates(logger);
+    // Skip version check if upgradeCheck is false
+    if (argv.upgradeCheck !== false) {
+      await checkForUpdates(logger);
+    }
 
-    if (!hasUserConsented()) {
+    // Skip user consent check if userWarning is false
+    if (!hasUserConsented() && argv.userWarning !== false) {
       const readline = createInterface({
         input: process.stdin,
         output: process.stdout,
@@ -81,6 +85,10 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
         logger.info('User did not consent. Exiting.');
         throw new Error('User did not consent');
       }
+    } else if (!hasUserConsented() && argv.userWarning === false) {
+      // Auto-save consent when userWarning is false
+      logger.debug('Skipping user consent check due to --userWarning=false');
+      saveUserConsent();
     }
 
     const tokenTracker = new TokenTracker(

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -16,6 +16,8 @@ export type SharedOptions = {
   readonly enableUserPrompt?: boolean;
   readonly userPrompt?: boolean;
   readonly githubMode?: boolean;
+  readonly userWarning?: boolean;
+  readonly upgradeCheck?: boolean;
 };
 
 export const sharedOptions = {
@@ -105,6 +107,16 @@ export const sharedOptions = {
   githubMode: {
     type: 'boolean',
     description: 'Enable GitHub mode for working with issues and PRs',
+    default: false,
+  } as const,
+  userWarning: {
+    type: 'boolean',
+    description: 'Disable user consent check (for automated/remote usage)',
+    default: false,
+  } as const,
+  upgradeCheck: {
+    type: 'boolean',
+    description: 'Disable version upgrade check (for automated/remote usage)',
     default: false,
   } as const,
 };

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -111,7 +111,8 @@ export const sharedOptions = {
   } as const,
   userWarning: {
     type: 'boolean',
-    description: 'Disable user consent check (for automated/remote usage)',
+    description:
+      'Skip user consent check for current session (does not save consent)',
     default: false,
   } as const,
   upgradeCheck: {


### PR DESCRIPTION
## Summary
This PR adds two new CLI options to support automated usage scenarios:
- `--userWarning=false` - Disables the user consent check
- `--upgradeCheck=false` - Disables the version upgrade check

## Problem
When running MyCoder in automated environments like CI/CD pipelines:
1. The user consent prompt blocks execution and requires manual intervention
2. The version upgrade check adds unnecessary output and network calls

## Solution
Added two boolean CLI options that can be set to `false` to disable these features:
- `--userWarning=false` bypasses the consent check
- `--upgradeCheck=false` skips the version check

## Changes
- Added new options to `SharedOptions` type and `sharedOptions` object in `options.ts`
- Updated consent check in `.ts` to respect the `userWarning` option
- Updated version check in `.ts` to respect the `upgradeCheck` option
- Updated documentation in README files