### PR TITLE
fix: convert absolute paths to relative paths in textEditor log output

### DIFF
--- a/packages/agent/src/tools/io/textEditor.ts
+++ b/packages/agent/src/tools/io/textEditor.ts
@@ -302,9 +302,19 @@ export const textEditorTool: Tool<Parameters, ReturnType> = {
         throw new Error(`Unknown command: ${command}`);
     }
   },
-  logParameters: (input, { logger }) => {
+  logParameters: (input, { logger, workingDirectory }) => {
+    // Convert absolute path to relative path if possible
+    let displayPath = input.path;
+    if (workingDirectory && path.isAbsolute(input.path)) {
+      // Check if the path is within the working directory
+      if (input.path.startsWith(workingDirectory)) {
+        // Convert to relative path with ./ prefix
+        displayPath = './' + path.relative(workingDirectory, input.path);
+      }
+    }
+
     logger.info(
-      `${input.command} operation on "${input.path}", ${input.description}`,
+      `${input.command} operation on "${displayPath}", ${input.description}`,
     );
   },
   logReturns: (result, { logger }) => {


### PR DESCRIPTION
## Description

This PR addresses issue #223 by modifying the textEditor tool to display relative paths instead of full absolute paths in log messages.

### Changes

- Modified the `logParameters` function in the textEditor tool to convert absolute paths to relative paths when the path is within the working directory
- Added comprehensive tests to verify the path conversion logic
- Ensured backward compatibility by preserving absolute paths for locations outside the working directory

### Example

Before:
```
view operation on "/Users/benhouston/Coding/Business/drivecore/mycoder2/packages/agent/src/core/llm/provider.ts", Viewing provider.ts merge conflict
```

After:
```
view operation on "./packages/agent/src/core/llm/provider.ts", Viewing provider.ts merge conflict
```

### Testing

Added unit tests that verify:
- Absolute paths within the working directory are converted to relative paths
- Absolute paths outside the working directory remain unchanged
- Relative paths remain unchanged

All existing tests continue to pass.

Closes #223