### PR TITLE
Check for git and gh CLI tools when GitHub mode is enabled

### DIFF
--- a/packages/cli/src/utils/gitCliCheck.test.ts
+++ b/packages/cli/src/utils/gitCliCheck.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkGitCli, GitCliCheckResult } from './gitCliCheck';
+
+// Mock the child_process module
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Mock the util module
+vi.mock('util', () => ({
+  promisify: vi.fn((fn) => {
+    return (cmd: string) => {
+      return new Promise((resolve, reject) => {
+        fn(cmd, (error: Error | null, result: { stdout: string }) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
+          }
+        });
+      });
+    };
+  }),
+}));
+
+// Import the mocked modules
+import { exec } from 'child_process';
+
+describe('gitCliCheck', () => {
+  const mockExec = exec as unknown as vi.Mock;
+  
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+  
+  it('should return all true when git and gh are available and authenticated', async () => {
+    // Mock successful responses
+    mockExec.mockImplementation((cmd: string, callback: Function) => {
+      if (cmd === 'git --version') {
+        callback(null, { stdout: 'git version 2.30.1' });
+      } else if (cmd === 'gh --version') {
+        callback(null, { stdout: 'gh version 2.0.0' });
+      } else if (cmd === 'gh auth status') {
+        callback(null, { stdout: 'Logged in to github.com as username' });
+      }
+    });
+    
+    const result = await checkGitCli();
+    
+    expect(result.gitAvailable).toBe(true);
+    expect(result.ghAvailable).toBe(true);
+    expect(result.ghAuthenticated).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+  
+  it('should detect when git is not available', async () => {
+    mockExec.mockImplementation((cmd: string, callback: Function) => {
+      if (cmd === 'git --version') {
+        callback(new Error('Command not found'));
+      } else if (cmd === 'gh --version') {
+        callback(null, { stdout: 'gh version 2.0.0' });
+      } else if (cmd === 'gh auth status') {
+        callback(null, { stdout: 'Logged in to github.com as username' });
+      }
+    });
+    
+    const result = await checkGitCli();
+    
+    expect(result.gitAvailable).toBe(false);
+    expect(result.ghAvailable).toBe(true);
+    expect(result.ghAuthenticated).toBe(true);
+    expect(result.errors).toContain('Git CLI is not available. Please install git.');
+  });
+  
+  it('should detect when gh is not available', async () => {
+    mockExec.mockImplementation((cmd: string, callback: Function) => {
+      if (cmd === 'git --version') {
+        callback(null, { stdout: 'git version 2.30.1' });
+      } else if (cmd === 'gh --version') {
+        callback(new Error('Command not found'));
+      }
+    });
+    
+    const result = await checkGitCli();
+    
+    expect(result.gitAvailable).toBe(true);
+    expect(result.ghAvailable).toBe(false);
+    expect(result.ghAuthenticated).toBe(false);
+    expect(result.errors).toContain('GitHub CLI is not available. Please install gh CLI.');
+  });
+  
+  it('should detect when gh is not authenticated', async () => {
+    mockExec.mockImplementation((cmd: string, callback: Function) => {
+      if (cmd === 'git --version') {
+        callback(null, { stdout: 'git version 2.30.1' });
+      } else if (cmd === 'gh --version') {
+        callback(null, { stdout: 'gh version 2.0.0' });
+      } else if (cmd === 'gh auth status') {
+        callback(new Error('You are not logged into any GitHub hosts'));
+      }
+    });
+    
+    const result = await checkGitCli();
+    
+    expect(result.gitAvailable).toBe(true);
+    expect(result.ghAvailable).toBe(true);
+    expect(result.ghAuthenticated).toBe(false);
+    expect(result.errors).toContain('GitHub CLI is not authenticated. Please run "gh auth login".');
+  });
+});

--- a/packages/cli/src/utils/gitCliCheck.ts
+++ b/packages/cli/src/utils/gitCliCheck.ts
@@ -1,0 +1,89 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { Logger } from 'mycoder-agent';
+
+const execAsync = promisify(exec);
+
+/**
+ * Result of CLI tool checks
+ */
+export interface GitCliCheckResult {
+  gitAvailable: boolean;
+  ghAvailable: boolean;
+  ghAuthenticated: boolean;
+  errors: string[];
+}
+
+/**
+ * Checks if git command is available
+ */
+async function checkGitAvailable(): Promise<boolean> {
+  try {
+    await execAsync('git --version');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Checks if gh command is available
+ */
+async function checkGhAvailable(): Promise<boolean> {
+  try {
+    await execAsync('gh --version');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Checks if gh is authenticated
+ */
+async function checkGhAuthenticated(): Promise<boolean> {
+  try {
+    const { stdout } = await execAsync('gh auth status');
+    return stdout.includes('Logged in to');
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Checks if git and gh CLI tools are available and if gh is authenticated
+ * @param logger Optional logger for debug output
+ * @returns Object with check results
+ */
+export async function checkGitCli(logger?: Logger): Promise<GitCliCheckResult> {
+  const result: GitCliCheckResult = {
+    gitAvailable: false,
+    ghAvailable: false,
+    ghAuthenticated: false,
+    errors: [],
+  };
+
+  logger?.debug('Checking for git CLI availability...');
+  result.gitAvailable = await checkGitAvailable();
+
+  logger?.debug('Checking for gh CLI availability...');
+  result.ghAvailable = await checkGhAvailable();
+
+  if (result.ghAvailable) {
+    logger?.debug('Checking for gh CLI authentication...');
+    result.ghAuthenticated = await checkGhAuthenticated();
+  }
+
+  // Collect any errors
+  if (!result.gitAvailable) {
+    result.errors.push('Git CLI is not available. Please install git.');
+  }
+  
+  if (!result.ghAvailable) {
+    result.errors.push('GitHub CLI is not available. Please install gh CLI.');
+  } else if (!result.ghAuthenticated) {
+    result.errors.push('GitHub CLI is not authenticated. Please run "gh auth login".');
+  }
+
+  return result;
+}


### PR DESCRIPTION
This PR adds a new feature to check for git and gh CLI tools when GitHub mode is enabled. 

## Changes

- Added a new utility function `checkGitCli()` that checks:
  - If git CLI is available
  - If gh CLI is available
  - If gh CLI is authenticated
- Added warning messages when GitHub mode is enabled but required tools are missing
- Added unit tests for the new functionality

## Implementation

The implementation adds a check in the main command handler that runs when GitHub mode is enabled. If git or gh CLI tools are not available or gh is not authenticated, appropriate warning messages are displayed to the user.

This helps users understand why GitHub mode might not be working as expected and provides guidance on how to fix the issues.

Fixes #217