### PR TITLE
feat: support multiple line custom prompts in mycoder.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ export default {
   temperature: 0.7,
 
   // Custom settings
+  // customPrompt can be a string or an array of strings for multiple lines
   customPrompt: '',
+  // Example of multiple line custom prompts:
+  // customPrompt: [
+  //   'Custom instruction line 1',
+  //   'Custom instruction line 2',
+  //   'Custom instruction line 3',
+  // ],
   profile: false,
   tokenCache: true,
 

--- a/mycoder.config.js
+++ b/mycoder.config.js
@@ -20,7 +20,14 @@ export default {
   temperature: 0.7,
 
   // Custom settings
+  // customPrompt can be a string or an array of strings for multiple lines
   customPrompt: '',
+  // Example of multiple line custom prompts:
+  // customPrompt: [
+  //   'Custom instruction line 1',
+  //   'Custom instruction line 2',
+  //   'Custom instruction line 3',
+  // ],
   profile: false,
   tokenCache: true,
 };

--- a/packages/agent/src/core/toolAgent/config.ts
+++ b/packages/agent/src/core/toolAgent/config.ts
@@ -199,6 +199,13 @@ export function getDefaultSystemPrompt(toolContext: ToolContext): string {
     'When you run into issues or unexpected results, take a step back and read the project documentation and configuration files and look at other source files in the project for examples of what works.',
     '',
     'Use sub-agents for parallel tasks, providing them with specific context they need rather than having them rediscover it.',
-    toolContext.customPrompt ? `\n\n${toolContext.customPrompt}` : '',
+    (() => {
+      if (!toolContext.customPrompt) return '';
+      if (typeof toolContext.customPrompt === 'string') {
+        return `\n\n${toolContext.customPrompt}`;
+      }
+      // It's an array of strings
+      return `\n\n${toolContext.customPrompt.join('\n')}`;
+    })(),
   ].join('\n');
 }

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -19,7 +19,7 @@ export type ToolContext = {
   pageFilter: pageFilter;
   tokenTracker: TokenTracker;
   githubMode: boolean;
-  customPrompt?: string;
+  customPrompt?: string | string[];
   tokenCache?: boolean;
   userPrompt?: boolean;
   agentId?: string; // Unique identifier for the agent, used for background tool tracking

--- a/packages/cli/src/settings/config.ts
+++ b/packages/cli/src/settings/config.ts
@@ -13,7 +13,7 @@ export type Config = {
   model: string;
   maxTokens: number;
   temperature: number;
-  customPrompt: string;
+  customPrompt: string | string[];
   profile: boolean;
   tokenCache: boolean;
   userPrompt: boolean;


### PR DESCRIPTION
## Description

This PR implements support for multiple line custom prompts in `mycoder.config.js` as requested in issue #249. Instead of only supporting a single line string, the `customPrompt` configuration option now accepts either a string (for backward compatibility) or an array of strings (for multiple line prompts).

## Changes

- Updated `customPrompt` type in `packages/agent/src/core/types.ts` to accept `string | string[]`
- Updated `customPrompt` type in `packages/cli/src/settings/config.ts` to accept `string | string[]`
- Modified system prompt generation in `packages/agent/src/core/toolAgent/config.ts` to handle both string and array formats
- Updated examples in `mycoder.config.js` and `README.md` to demonstrate the new feature

## Example Usage

Users can now define custom prompts in two ways:

```js
// Single line (existing behavior)
customPrompt: 'Single line custom prompt',

// Multiple lines (new behavior)
customPrompt: [
  'First line of custom prompt',
  'Second line of custom prompt',
  'Third line of custom prompt',
],
```

## Testing

All existing tests pass, confirming backward compatibility with the current string-based approach.

Closes #249