### PR TITLE
feat: replace cosmiconfig with c12 for configuration management

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,8 +46,8 @@
   "license": "MIT",
   "dependencies": {
     "@sentry/node": "^9.3.0",
+    "c12": "^3.0.2",
     "chalk": "^5",
-    "cosmiconfig": "^9.0.0",
     "deepmerge": "^4.3.1",
     "dotenv": "^16",
     "mycoder-agent": "workspace:*",

--- a/packages/cli/src/settings/config.ts
+++ b/packages/cli/src/settings/config.ts
@@ -1,4 +1,4 @@
-import { cosmiconfig } from 'cosmiconfig';
+import { loadConfig as loadC12Config, watchConfig } from 'c12';
 import { ArgumentsCamelCase } from 'yargs';
 
 import { SharedOptions } from '../options';
@@ -107,12 +107,6 @@ export const getConfigFromArgv = (argv: ArgumentsCamelCase<SharedOptions>) => {
   };
 };
 
-function removeUndefined(obj: any) {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([_, value]) => value !== undefined),
-  );
-}
-
 /**
  * Validates custom commands configuration
  * @param config The configuration object
@@ -138,32 +132,53 @@ function validateCustomCommands(config: Config): void {
   });
 }
 /**
- * Load configuration using cosmiconfig
+ * Load configuration using c12
  * @returns Merged configuration with default values
  */
 export async function loadConfig(
   cliOptions: Partial<Config> = {},
 ): Promise<Config> {
-  // Initialize cosmiconfig
-  const explorer = cosmiconfig('mycoder', {
-    searchStrategy: 'global',
+  // Load configuration using c12
+  const { config } = await loadC12Config({
+    name: 'mycoder',
+    defaults: defaultConfig,
+    overrides: cliOptions,
+    // Optionally enable .env support
+    // dotenv: true,
   });
 
-  // Search for configuration file
-  const result = await explorer.search();
+  // Convert to Config type and validate custom commands
+  const typedConfig = config as unknown as Config;
+  validateCustomCommands(typedConfig);
 
-  // Merge configurations with precedence: default < file < cli
-  const fileConfig = result?.config || {};
+  return typedConfig;
+}
 
-  // Return merged configuration
-  const mergedConfig = {
-    ...defaultConfig,
-    ...removeUndefined(fileConfig),
-    ...removeUndefined(cliOptions),
+/**
+ * Watch configuration for changes
+ * @param cliOptions CLI options to override configuration
+ * @param onUpdate Callback when configuration is updated
+ */
+export async function watchConfigForChanges(
+  cliOptions: Partial<Config> = {},
+  onUpdate?: (config: Config) => void,
+) {
+  const { config, watchingFiles, unwatch } = await watchConfig({
+    name: 'mycoder',
+    defaults: defaultConfig,
+    overrides: cliOptions,
+    onUpdate: ({ newConfig }) => {
+      const typedConfig = newConfig as unknown as Config;
+      validateCustomCommands(typedConfig);
+      if (onUpdate) {
+        onUpdate(typedConfig);
+      }
+    },
+  });
+
+  return {
+    config: config as unknown as Config,
+    watchingFiles,
+    unwatch,
   };
-
-  // Validate custom commands if present
-  validateCustomCommands(mergedConfig);
-
-  return mergedConfig;
 }


### PR DESCRIPTION
## Replace cosmiconfig with c12 for configuration management

This PR replaces cosmiconfig with c12 for better TypeScript support and additional configuration features, as requested in issue #260.

### Changes

- Replaced cosmiconfig with c12 for configuration loading
- Added configuration watching capability via `watchConfigForChanges` function
- Removed dependency on cosmiconfig
- Maintained backward compatibility with existing configuration files
- Fixed type issues when working with c12's configuration types

### Benefits of c12 over cosmiconfig

1. **TypeScript Support**: c12 has built-in TypeScript support without requiring custom loaders
2. **More Configuration Formats**: Supports JSONC, JSON5, TOML in addition to standard formats
3. **Configuration Directory**: Supports a `.config/` directory for organizing configuration files
4. **Environment-specific Configurations**: Allows for environment-specific configuration files
5. **Extended Configurations**: Supports extending configurations from other files or packages
6. **Configuration Watching**: Built-in support for watching configuration files for changes
7. **Dotenv Support**: Built-in support for loading environment variables from .env files
8. **Active Development**: Part of the UnJS ecosystem, actively maintained

### Testing

- All tests pass with the new implementation
- The API remains compatible with existing code

Closes #260