### PR TITLE
feat: implement ShellTracker to decouple from backgroundTools

### DIFF
--- a/packages/agent/src/core/backgroundTools.test.ts
+++ b/packages/agent/src/core/backgroundTools.test.ts
@@ -19,22 +19,6 @@ describe('BackgroundToolRegistry', () => {
     backgroundTools.tools = new Map();
   });
 
-  it('should register a shell process', () => {
-    const id = backgroundTools.registerShell('ls -la');
-
-    expect(id).toBe('test-id-1');
-
-    const tool = backgroundTools.getToolById(id);
-    expect(tool).toBeDefined();
-    if (tool) {
-      expect(tool.type).toBe(BackgroundToolType.SHELL);
-      expect(tool.status).toBe(BackgroundToolStatus.RUNNING);
-      if (tool.type === BackgroundToolType.SHELL) {
-        expect(tool.metadata.command).toBe('ls -la');
-      }
-    }
-  });
-
   it('should register a browser process', () => {
     const id = backgroundTools.registerBrowser('https://example.com');
 
@@ -47,30 +31,6 @@ describe('BackgroundToolRegistry', () => {
       expect(tool.status).toBe(BackgroundToolStatus.RUNNING);
       if (tool.type === BackgroundToolType.BROWSER) {
         expect(tool.metadata.url).toBe('https://example.com');
-      }
-    }
-  });
-
-  it('should update tool status', () => {
-    const id = backgroundTools.registerShell('sleep 10');
-
-    const updated = backgroundTools.updateToolStatus(
-      id,
-      BackgroundToolStatus.COMPLETED,
-      {
-        exitCode: 0,
-      },
-    );
-
-    expect(updated).toBe(true);
-
-    const tool = backgroundTools.getToolById(id);
-    expect(tool).toBeDefined();
-    if (tool) {
-      expect(tool.status).toBe(BackgroundToolStatus.COMPLETED);
-      expect(tool.endTime).toBeDefined();
-      if (tool.type === BackgroundToolType.SHELL) {
-        expect(tool.metadata.exitCode).toBe(0);
       }
     }
   });
@@ -91,33 +51,33 @@ describe('BackgroundToolRegistry', () => {
     // Add a completed tool from 25 hours ago
     const oldTool = {
       id: 'old-tool',
-      type: BackgroundToolType.SHELL,
+      type: BackgroundToolType.BROWSER,
       status: BackgroundToolStatus.COMPLETED,
       startTime: new Date(Date.now() - 25 * 60 * 60 * 1000),
       endTime: new Date(Date.now() - 25 * 60 * 60 * 1000),
       agentId: 'agent-1',
-      metadata: { command: 'echo old' },
+      metadata: { url: 'https://example.com' },
     };
 
     // Add a completed tool from 10 hours ago
     const recentTool = {
       id: 'recent-tool',
-      type: BackgroundToolType.SHELL,
+      type: BackgroundToolType.BROWSER,
       status: BackgroundToolStatus.COMPLETED,
       startTime: new Date(Date.now() - 10 * 60 * 60 * 1000),
       endTime: new Date(Date.now() - 10 * 60 * 60 * 1000),
       agentId: 'agent-1',
-      metadata: { command: 'echo recent' },
+      metadata: { url: 'https://example.com' },
     };
 
     // Add a running tool from 25 hours ago
     const oldRunningTool = {
       id: 'old-running-tool',
-      type: BackgroundToolType.SHELL,
+      type: BackgroundToolType.BROWSER,
       status: BackgroundToolStatus.RUNNING,
       startTime: new Date(Date.now() - 25 * 60 * 60 * 1000),
       agentId: 'agent-1',
-      metadata: { command: 'sleep 100' },
+      metadata: { url: 'https://example.com' },
     };
 
     registry.tools.set('old-tool', oldTool);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,6 +10,8 @@ export * from './tools/system/sequenceComplete.js';
 export * from './tools/system/shellMessage.js';
 export * from './tools/system/shellExecute.js';
 export * from './tools/system/listBackgroundTools.js';
+export * from './tools/system/listShells.js';
+export * from './tools/system/ShellTracker.js';
 
 // Tools - Browser
 export * from './tools/browser/BrowserManager.js';

--- a/packages/agent/src/tools/getTools.ts
+++ b/packages/agent/src/tools/getTools.ts
@@ -10,6 +10,7 @@ import { fetchTool } from './io/fetch.js';
 import { textEditorTool } from './io/textEditor.js';
 import { createMcpTool } from './mcp.js';
 import { listBackgroundToolsTool } from './system/listBackgroundTools.js';
+import { listShellsTool } from './system/listShells.js';
 import { sequenceCompleteTool } from './system/sequenceComplete.js';
 import { shellMessageTool } from './system/shellMessage.js';
 import { shellStartTool } from './system/shellStart.js';
@@ -41,6 +42,7 @@ export function getTools(options?: GetToolsOptions): Tool[] {
     //respawnTool as unknown as Tool,  this is a confusing tool for now.
     sleepTool as unknown as Tool,
     listBackgroundToolsTool as unknown as Tool,
+    listShellsTool as unknown as Tool,
   ];
 
   // Only include userPrompt tool if enabled

--- a/packages/agent/src/tools/system/ShellTracker.test.ts
+++ b/packages/agent/src/tools/system/ShellTracker.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ShellStatus, shellTracker } from './ShellTracker.js';
+
+// Mock uuid to return predictable IDs for testing
+vi.mock('uuid', () => ({
+  v4: vi
+    .fn()
+    .mockReturnValueOnce('test-id-1')
+    .mockReturnValueOnce('test-id-2')
+    .mockReturnValueOnce('test-id-3'),
+}));
+
+describe('ShellTracker', () => {
+  beforeEach(() => {
+    // Clear all registered shells before each test
+    shellTracker['shells'] = new Map();
+    shellTracker.processStates.clear();
+  });
+
+  it('should register a shell process', () => {
+    const id = shellTracker.registerShell('ls -la');
+
+    expect(id).toBe('test-id-1');
+
+    const shell = shellTracker.getShellById(id);
+    expect(shell).toBeDefined();
+    if (shell) {
+      expect(shell.status).toBe(ShellStatus.RUNNING);
+      expect(shell.metadata.command).toBe('ls -la');
+    }
+  });
+
+  it('should update shell status', () => {
+    const id = shellTracker.registerShell('sleep 10');
+
+    const updated = shellTracker.updateShellStatus(id, ShellStatus.COMPLETED, {
+      exitCode: 0,
+    });
+
+    expect(updated).toBe(true);
+
+    const shell = shellTracker.getShellById(id);
+    expect(shell).toBeDefined();
+    if (shell) {
+      expect(shell.status).toBe(ShellStatus.COMPLETED);
+      expect(shell.endTime).toBeDefined();
+      expect(shell.metadata.exitCode).toBe(0);
+    }
+  });
+
+  it('should return false when updating non-existent shell', () => {
+    const updated = shellTracker.updateShellStatus(
+      'non-existent-id',
+      ShellStatus.COMPLETED,
+    );
+
+    expect(updated).toBe(false);
+  });
+
+  it('should filter shells by status', () => {
+    // Create shells with different statuses
+    const shell1 = {
+      id: 'shell-1',
+      status: ShellStatus.RUNNING,
+      startTime: new Date(),
+      metadata: {
+        command: 'command1',
+      },
+    };
+
+    const shell2 = {
+      id: 'shell-2',
+      status: ShellStatus.COMPLETED,
+      startTime: new Date(),
+      endTime: new Date(),
+      metadata: {
+        command: 'command2',
+        exitCode: 0,
+      },
+    };
+
+    const shell3 = {
+      id: 'shell-3',
+      status: ShellStatus.ERROR,
+      startTime: new Date(),
+      endTime: new Date(),
+      metadata: {
+        command: 'command3',
+        exitCode: 1,
+        error: 'Error message',
+      },
+    };
+
+    // Add the shells directly to the map
+    shellTracker['shells'].set('shell-1', shell1);
+    shellTracker['shells'].set('shell-2', shell2);
+    shellTracker['shells'].set('shell-3', shell3);
+
+    // Get all shells
+    const allShells = shellTracker.getShells();
+    expect(allShells.length).toBe(3);
+
+    // Get running shells
+    const runningShells = shellTracker.getShells(ShellStatus.RUNNING);
+    expect(runningShells.length).toBe(1);
+    expect(runningShells[0].id).toBe('shell-1');
+
+    // Get completed shells
+    const completedShells = shellTracker.getShells(ShellStatus.COMPLETED);
+    expect(completedShells.length).toBe(1);
+    expect(completedShells[0].id).toBe('shell-2');
+
+    // Get error shells
+    const errorShells = shellTracker.getShells(ShellStatus.ERROR);
+    expect(errorShells.length).toBe(1);
+    expect(errorShells[0].id).toBe('shell-3');
+  });
+});

--- a/packages/agent/src/tools/system/ShellTracker.test.ts
+++ b/packages/agent/src/tools/system/ShellTracker.test.ts
@@ -104,16 +104,19 @@ describe('ShellTracker', () => {
     // Get running shells
     const runningShells = shellTracker.getShells(ShellStatus.RUNNING);
     expect(runningShells.length).toBe(1);
-    expect(runningShells[0].id).toBe('shell-1');
+    expect(runningShells.length).toBe(1);
+    expect(runningShells[0]!.id).toBe('shell-1');
 
     // Get completed shells
     const completedShells = shellTracker.getShells(ShellStatus.COMPLETED);
     expect(completedShells.length).toBe(1);
-    expect(completedShells[0].id).toBe('shell-2');
+    expect(completedShells.length).toBe(1);
+    expect(completedShells[0]!.id).toBe('shell-2');
 
     // Get error shells
     const errorShells = shellTracker.getShells(ShellStatus.ERROR);
     expect(errorShells.length).toBe(1);
-    expect(errorShells[0].id).toBe('shell-3');
+    expect(errorShells.length).toBe(1);
+    expect(errorShells[0]!.id).toBe('shell-3');
   });
 });

--- a/packages/agent/src/tools/system/ShellTracker.ts
+++ b/packages/agent/src/tools/system/ShellTracker.ts
@@ -1,0 +1,171 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import type { ChildProcess } from 'child_process';
+
+// Status of a shell process
+export enum ShellStatus {
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  ERROR = 'error',
+  TERMINATED = 'terminated',
+}
+
+// Define ProcessState type
+export type ProcessState = {
+  process: ChildProcess;
+  command: string;
+  stdout: string[];
+  stderr: string[];
+  state: {
+    completed: boolean;
+    signaled: boolean;
+    exitCode: number | null;
+  };
+  showStdIn: boolean;
+  showStdout: boolean;
+};
+
+// Shell process specific data
+export interface ShellProcess {
+  id: string;
+  status: ShellStatus;
+  startTime: Date;
+  endTime?: Date;
+  metadata: {
+    command: string;
+    exitCode?: number | null;
+    signaled?: boolean;
+    error?: string;
+    [key: string]: any; // Additional shell-specific information
+  };
+}
+
+/**
+ * Registry to keep track of shell processes
+ */
+export class ShellTracker {
+  private static instance: ShellTracker;
+  private shells: Map<string, ShellProcess> = new Map();
+  public processStates: Map<string, ProcessState> = new Map();
+
+  // Private constructor for singleton pattern
+  private constructor() {}
+
+  // Get the singleton instance
+  public static getInstance(): ShellTracker {
+    if (!ShellTracker.instance) {
+      ShellTracker.instance = new ShellTracker();
+    }
+    return ShellTracker.instance;
+  }
+
+  // Register a new shell process
+  public registerShell(command: string): string {
+    const id = uuidv4();
+    const shell: ShellProcess = {
+      id,
+      status: ShellStatus.RUNNING,
+      startTime: new Date(),
+      metadata: {
+        command,
+      },
+    };
+    this.shells.set(id, shell);
+    return id;
+  }
+
+  // Update the status of a shell process
+  public updateShellStatus(
+    id: string,
+    status: ShellStatus,
+    metadata?: Record<string, any>,
+  ): boolean {
+    const shell = this.shells.get(id);
+    if (!shell) {
+      return false;
+    }
+
+    shell.status = status;
+
+    if (
+      status === ShellStatus.COMPLETED ||
+      status === ShellStatus.ERROR ||
+      status === ShellStatus.TERMINATED
+    ) {
+      shell.endTime = new Date();
+    }
+
+    if (metadata) {
+      shell.metadata = { ...shell.metadata, ...metadata };
+    }
+
+    return true;
+  }
+
+  // Get all shell processes
+  public getShells(status?: ShellStatus): ShellProcess[] {
+    const result: ShellProcess[] = [];
+    for (const shell of this.shells.values()) {
+      if (!status || shell.status === status) {
+        result.push(shell);
+      }
+    }
+    return result;
+  }
+
+  // Get a specific shell process by ID
+  public getShellById(id: string): ShellProcess | undefined {
+    return this.shells.get(id);
+  }
+
+  /**
+   * Cleans up a shell process
+   * @param id The ID of the shell process to clean up
+   */
+  public async cleanupShellProcess(id: string): Promise<void> {
+    try {
+      const shell = this.shells.get(id);
+      if (!shell) {
+        return;
+      }
+
+      const processState = this.processStates.get(id);
+      if (processState && !processState.state.completed) {
+        processState.process.kill('SIGTERM');
+
+        // Force kill after a short timeout if still running
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            try {
+              if (!processState.state.completed) {
+                processState.process.kill('SIGKILL');
+              }
+            } catch {
+              // Ignore errors on forced kill
+            }
+            resolve();
+          }, 500);
+        });
+      }
+      this.updateShellStatus(id, ShellStatus.TERMINATED);
+    } catch (error) {
+      this.updateShellStatus(id, ShellStatus.ERROR, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Cleans up all running shell processes
+   */
+  public async cleanupAllShells(): Promise<void> {
+    const runningShells = this.getShells(ShellStatus.RUNNING);
+    const cleanupPromises = runningShells.map((shell) =>
+      this.cleanupShellProcess(shell.id),
+    );
+    await Promise.all(cleanupPromises);
+  }
+}
+
+// Export a singleton instance
+export const shellTracker = ShellTracker.getInstance();

--- a/packages/agent/src/tools/system/listBackgroundTools.ts
+++ b/packages/agent/src/tools/system/listBackgroundTools.ts
@@ -10,7 +10,7 @@ const parameterSchema = z.object({
     .optional()
     .describe('Filter tools by status (default: "all")'),
   type: z
-    .enum(['all', 'shell', 'browser', 'agent'])
+    .enum(['all', 'browser', 'agent'])
     .optional()
     .describe('Filter tools by type (default: "all")'),
   verbose: z
@@ -39,8 +39,7 @@ type ReturnType = z.infer<typeof returnSchema>;
 
 export const listBackgroundToolsTool: Tool<Parameters, ReturnType> = {
   name: 'listBackgroundTools',
-  description:
-    'Lists all background tools (shells, browsers, agents) and their status',
+  description: 'Lists all background tools (browsers, agents) and their status',
   logPrefix: '🔍',
   parameters: parameterSchema,
   returns: returnSchema,

--- a/packages/agent/src/tools/system/listShells.test.ts
+++ b/packages/agent/src/tools/system/listShells.test.ts
@@ -81,8 +81,9 @@ describe('listShellsTool', () => {
 
     expect(result.shells.length).toBe(1);
     expect(result.count).toBe(1);
-    expect(result.shells[0].id).toBe('shell-1');
-    expect(result.shells[0].status).toBe(ShellStatus.RUNNING);
+    expect(result.shells.length).toBe(1);
+    expect(result.shells[0]!.id).toBe('shell-1');
+    expect(result.shells[0]!.status).toBe(ShellStatus.RUNNING);
   });
 
   it('should include metadata when verbose is true', async () => {
@@ -105,9 +106,10 @@ describe('listShellsTool', () => {
     );
 
     expect(result.shells.length).toBe(1);
-    expect(result.shells[0].id).toBe('shell-3');
-    expect(result.shells[0].status).toBe(ShellStatus.ERROR);
-    expect(result.shells[0].metadata).toBeDefined();
-    expect(result.shells[0].metadata?.error).toBe('Command not found');
+    expect(result.shells.length).toBe(1);
+    expect(result.shells[0]!.id).toBe('shell-3');
+    expect(result.shells[0]!.status).toBe(ShellStatus.ERROR);
+    expect(result.shells[0]!.metadata).toBeDefined();
+    expect(result.shells[0]!.metadata?.error).toBe('Command not found');
   });
 });

--- a/packages/agent/src/tools/system/listShells.test.ts
+++ b/packages/agent/src/tools/system/listShells.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ToolContext } from '../../core/types.js';
+import { getMockToolContext } from '../getTools.test.js';
+
+import { listShellsTool } from './listShells.js';
+import { ShellStatus, shellTracker } from './ShellTracker.js';
+
+const toolContext: ToolContext = getMockToolContext();
+
+// Mock Date.now to return a consistent timestamp
+const mockNow = new Date('2023-01-01T00:00:00Z').getTime();
+vi.spyOn(Date, 'now').mockImplementation(() => mockNow);
+
+describe('listShellsTool', () => {
+  beforeEach(() => {
+    // Clear shells before each test
+    shellTracker['shells'] = new Map();
+
+    // Set up some test shells with different statuses
+    const shell1 = {
+      id: 'shell-1',
+      status: ShellStatus.RUNNING,
+      startTime: new Date(mockNow - 1000 * 60 * 5), // 5 minutes ago
+      metadata: {
+        command: 'sleep 100',
+      },
+    };
+
+    const shell2 = {
+      id: 'shell-2',
+      status: ShellStatus.COMPLETED,
+      startTime: new Date(mockNow - 1000 * 60 * 10), // 10 minutes ago
+      endTime: new Date(mockNow - 1000 * 60 * 9), // 9 minutes ago
+      metadata: {
+        command: 'echo "test"',
+        exitCode: 0,
+      },
+    };
+
+    const shell3 = {
+      id: 'shell-3',
+      status: ShellStatus.ERROR,
+      startTime: new Date(mockNow - 1000 * 60 * 15), // 15 minutes ago
+      endTime: new Date(mockNow - 1000 * 60 * 14), // 14 minutes ago
+      metadata: {
+        command: 'nonexistentcommand',
+        exitCode: 127,
+        error: 'Command not found',
+      },
+    };
+
+    // Add the shells to the tracker
+    shellTracker['shells'].set('shell-1', shell1);
+    shellTracker['shells'].set('shell-2', shell2);
+    shellTracker['shells'].set('shell-3', shell3);
+  });
+
+  it('should list all shells by default', async () => {
+    const result = await listShellsTool.execute({}, toolContext);
+
+    expect(result.shells.length).toBe(3);
+    expect(result.count).toBe(3);
+
+    // Check that shells are properly formatted
+    const shell1 = result.shells.find((s) => s.id === 'shell-1');
+    expect(shell1).toBeDefined();
+    expect(shell1?.status).toBe(ShellStatus.RUNNING);
+    expect(shell1?.command).toBe('sleep 100');
+    expect(shell1?.runtime).toBeGreaterThan(0);
+
+    // Metadata should not be included by default
+    expect(shell1?.metadata).toBeUndefined();
+  });
+
+  it('should filter shells by status', async () => {
+    const result = await listShellsTool.execute(
+      { status: 'running' },
+      toolContext,
+    );
+
+    expect(result.shells.length).toBe(1);
+    expect(result.count).toBe(1);
+    expect(result.shells[0].id).toBe('shell-1');
+    expect(result.shells[0].status).toBe(ShellStatus.RUNNING);
+  });
+
+  it('should include metadata when verbose is true', async () => {
+    const result = await listShellsTool.execute({ verbose: true }, toolContext);
+
+    expect(result.shells.length).toBe(3);
+
+    // Check that metadata is included
+    const shell3 = result.shells.find((s) => s.id === 'shell-3');
+    expect(shell3).toBeDefined();
+    expect(shell3?.metadata).toBeDefined();
+    expect(shell3?.metadata?.exitCode).toBe(127);
+    expect(shell3?.metadata?.error).toBe('Command not found');
+  });
+
+  it('should combine status filter with verbose option', async () => {
+    const result = await listShellsTool.execute(
+      { status: 'error', verbose: true },
+      toolContext,
+    );
+
+    expect(result.shells.length).toBe(1);
+    expect(result.shells[0].id).toBe('shell-3');
+    expect(result.shells[0].status).toBe(ShellStatus.ERROR);
+    expect(result.shells[0].metadata).toBeDefined();
+    expect(result.shells[0].metadata?.error).toBe('Command not found');
+  });
+});

--- a/packages/agent/src/tools/system/listShells.ts
+++ b/packages/agent/src/tools/system/listShells.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { Tool } from '../../core/types.js';
+
+import { ShellStatus, shellTracker } from './ShellTracker.js';
+
+const parameterSchema = z.object({
+  status: z
+    .enum(['all', 'running', 'completed', 'error', 'terminated'])
+    .optional()
+    .describe('Filter shells by status (default: "all")'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe('Include detailed metadata about each shell (default: false)'),
+});
+
+const returnSchema = z.object({
+  shells: z.array(
+    z.object({
+      id: z.string(),
+      status: z.string(),
+      startTime: z.string(),
+      endTime: z.string().optional(),
+      runtime: z.number().describe('Runtime in seconds'),
+      command: z.string(),
+      metadata: z.record(z.any()).optional(),
+    }),
+  ),
+  count: z.number(),
+});
+
+type Parameters = z.infer<typeof parameterSchema>;
+type ReturnType = z.infer<typeof returnSchema>;
+
+export const listShellsTool: Tool<Parameters, ReturnType> = {
+  name: 'listShells',
+  description: 'Lists all shell processes and their status',
+  logPrefix: '🔍',
+  parameters: parameterSchema,
+  returns: returnSchema,
+  parametersJsonSchema: zodToJsonSchema(parameterSchema),
+  returnsJsonSchema: zodToJsonSchema(returnSchema),
+
+  execute: async (
+    { status = 'all', verbose = false },
+    { logger },
+  ): Promise<ReturnType> => {
+    logger.verbose(
+      `Listing shell processes with status: ${status}, verbose: ${verbose}`,
+    );
+
+    // Get all shells
+    let shells = shellTracker.getShells();
+
+    // Filter by status if specified
+    if (status !== 'all') {
+      const statusEnum = status.toUpperCase() as keyof typeof ShellStatus;
+      shells = shells.filter(
+        (shell) => shell.status === ShellStatus[statusEnum],
+      );
+    }
+
+    // Format the response
+    const formattedShells = shells.map((shell) => {
+      const now = new Date();
+      const startTime = shell.startTime;
+      const endTime = shell.endTime || now;
+      const runtime = (endTime.getTime() - startTime.getTime()) / 1000; // in seconds
+
+      return {
+        id: shell.id,
+        status: shell.status,
+        startTime: startTime.toISOString(),
+        ...(shell.endTime && { endTime: shell.endTime.toISOString() }),
+        runtime: parseFloat(runtime.toFixed(2)),
+        command: shell.metadata.command,
+        ...(verbose && { metadata: shell.metadata }),
+      };
+    });
+
+    return {
+      shells: formattedShells,
+      count: formattedShells.length,
+    };
+  },
+
+  logParameters: ({ status = 'all', verbose = false }, { logger }) => {
+    logger.info(
+      `Listing shell processes with status: ${status}, verbose: ${verbose}`,
+    );
+  },
+
+  logReturns: (output, { logger }) => {
+    logger.info(`Found ${output.count} shell processes`);
+  },
+};

--- a/packages/agent/src/tools/system/shellMessage.test.ts
+++ b/packages/agent/src/tools/system/shellMessage.test.ts
@@ -5,7 +5,8 @@ import { sleep } from '../../utils/sleep.js';
 import { getMockToolContext } from '../getTools.test.js';
 
 import { shellMessageTool, NodeSignals } from './shellMessage.js';
-import { processStates, shellStartTool } from './shellStart.js';
+import { shellStartTool } from './shellStart.js';
+import { shellTracker } from './ShellTracker.js';
 
 const toolContext: ToolContext = getMockToolContext();
 
@@ -23,14 +24,14 @@ describe('shellMessageTool', () => {
   let testInstanceId = '';
 
   beforeEach(() => {
-    processStates.clear();
+    shellTracker.processStates.clear();
   });
 
   afterEach(() => {
-    for (const processState of processStates.values()) {
+    for (const processState of shellTracker.processStates.values()) {
       processState.process.kill();
     }
-    processStates.clear();
+    shellTracker.processStates.clear();
   });
 
   it('should interact with a running process', async () => {
@@ -62,7 +63,7 @@ describe('shellMessageTool', () => {
     expect(result.completed).toBe(false);
 
     // Verify the instance ID is valid
-    expect(processStates.has(testInstanceId)).toBe(true);
+    expect(shellTracker.processStates.has(testInstanceId)).toBe(true);
   });
 
   it('should handle nonexistent process', async () => {
@@ -104,7 +105,7 @@ describe('shellMessageTool', () => {
 
     expect(result.completed).toBe(true);
     // Process should still be in processStates even after completion
-    expect(processStates.has(instanceId)).toBe(true);
+    expect(shellTracker.processStates.has(instanceId)).toBe(true);
   });
 
   it('should handle SIGTERM signal correctly', async () => {
@@ -207,7 +208,7 @@ describe('shellMessageTool', () => {
 
     expect(checkResult.signaled).toBe(true);
     expect(checkResult.completed).toBe(true);
-    expect(processStates.has(instanceId)).toBe(true);
+    expect(shellTracker.processStates.has(instanceId)).toBe(true);
   });
 
   it('should respect showStdIn and showStdout parameters', async () => {
@@ -224,7 +225,7 @@ describe('shellMessageTool', () => {
     const instanceId = getInstanceId(startResult);
 
     // Verify process state has default visibility settings
-    const processState = processStates.get(instanceId);
+    const processState = shellTracker.processStates.get(instanceId);
     expect(processState?.showStdIn).toBe(false);
     expect(processState?.showStdout).toBe(false);
 
@@ -241,7 +242,7 @@ describe('shellMessageTool', () => {
     );
 
     // Verify process state still exists
-    expect(processStates.has(instanceId)).toBe(true);
+    expect(shellTracker.processStates.has(instanceId)).toBe(true);
   });
 
   it('should inherit visibility settings from process state', async () => {
@@ -260,7 +261,7 @@ describe('shellMessageTool', () => {
     const instanceId = getInstanceId(startResult);
 
     // Verify process state has the specified visibility settings
-    const processState = processStates.get(instanceId);
+    const processState = shellTracker.processStates.get(instanceId);
     expect(processState?.showStdIn).toBe(true);
     expect(processState?.showStdout).toBe(true);
 
@@ -275,6 +276,6 @@ describe('shellMessageTool', () => {
     );
 
     // Verify process state still exists
-    expect(processStates.has(instanceId)).toBe(true);
+    expect(shellTracker.processStates.has(instanceId)).toBe(true);
   });
 });

--- a/packages/agent/src/tools/system/shellStart.test.ts
+++ b/packages/agent/src/tools/system/shellStart.test.ts
@@ -4,20 +4,21 @@ import { ToolContext } from '../../core/types.js';
 import { sleep } from '../../utils/sleep.js';
 import { getMockToolContext } from '../getTools.test.js';
 
-import { processStates, shellStartTool } from './shellStart.js';
+import { shellStartTool } from './shellStart.js';
+import { shellTracker } from './ShellTracker.js';
 
 const toolContext: ToolContext = getMockToolContext();
 
 describe('shellStartTool', () => {
   beforeEach(() => {
-    processStates.clear();
+    shellTracker.processStates.clear();
   });
 
   afterEach(() => {
-    for (const processState of processStates.values()) {
+    for (const processState of shellTracker.processStates.values()) {
       processState.process.kill();
     }
-    processStates.clear();
+    shellTracker.processStates.clear();
   });
 
   it('should handle fast commands in sync mode', async () => {
@@ -83,7 +84,7 @@ describe('shellStartTool', () => {
     );
 
     // Even sync results should be in processStates
-    expect(processStates.size).toBeGreaterThan(0);
+    expect(shellTracker.processStates.size).toBeGreaterThan(0);
     expect(syncResult.mode).toBe('sync');
     expect(syncResult.error).toBeUndefined();
     if (syncResult.mode === 'sync') {
@@ -101,7 +102,7 @@ describe('shellStartTool', () => {
     );
 
     if (asyncResult.mode === 'async') {
-      expect(processStates.has(asyncResult.instanceId)).toBe(true);
+      expect(shellTracker.processStates.has(asyncResult.instanceId)).toBe(true);
     }
   });
 
@@ -120,7 +121,7 @@ describe('shellStartTool', () => {
       expect(result.instanceId).toBeDefined();
       expect(result.error).toBeUndefined();
 
-      const processState = processStates.get(result.instanceId);
+      const processState = shellTracker.processStates.get(result.instanceId);
       expect(processState).toBeDefined();
 
       if (processState?.process.stdin) {
@@ -177,7 +178,9 @@ describe('shellStartTool', () => {
     );
 
     if (asyncResult.mode === 'async') {
-      const processState = processStates.get(asyncResult.instanceId);
+      const processState = shellTracker.processStates.get(
+        asyncResult.instanceId,
+      );
       expect(processState).toBeDefined();
       expect(processState?.showStdIn).toBe(true);
       expect(processState?.showStdout).toBe(true);


### PR DESCRIPTION
# Shell Process Tracking Decoupled from Background Tools

## Description

This PR implements a dedicated `ShellTracker` class to handle shell process tracking, decoupling it from the general `backgroundTools` implementation. This change improves modularity and separation of concerns.

## Changes

- Created a new `ShellTracker` class with methods for tracking shell processes
- Implemented a new `listShells` tool to list shell processes
- Updated `shellStart` and `shellMessage` to use the new `ShellTracker` instead of `backgroundTools`
- Modified `backgroundTools` to remove shell-specific functionality and use `ShellTracker` for cleanup
- Updated `listBackgroundTools` to exclude shell processes (now handled by `listShells`)
- Added tests for the new `ShellTracker` class and `listShells` tool
- Updated existing tests to work with the new structure

## Testing

All tests are passing. The implementation maintains backward compatibility while providing a cleaner separation of concerns.

## Additional Notes

This change is part of a larger effort to make the codebase more modular and easier to maintain.
