### PR TITLE
feat(agent): Decouple Browser Session Tracking from backgroundTools

### DIFF
--- a/packages/agent/src/core/backgroundTools.test.ts
+++ b/packages/agent/src/core/backgroundTools.test.ts
@@ -35,21 +35,7 @@ describe('BackgroundToolRegistry', () => {
     }
   });
 
-  it('should register a browser process', () => {
-    const id = backgroundTools.registerBrowser('https://example.com');
-
-    expect(id).toBe('test-id-1');
-
-    const tool = backgroundTools.getToolById(id);
-    expect(tool).toBeDefined();
-    if (tool) {
-      expect(tool.type).toBe(BackgroundToolType.BROWSER);
-      expect(tool.status).toBe(BackgroundToolStatus.RUNNING);
-      if (tool.type === BackgroundToolType.BROWSER) {
-        expect(tool.metadata.url).toBe('https://example.com');
-      }
-    }
-  });
+  // Browser registration test removed since browser tracking is now decoupled
 
   it('should update tool status', () => {
     const id = backgroundTools.registerShell('sleep 10');

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -23,6 +23,7 @@ export type ToolContext = {
   tokenCache?: boolean;
   userPrompt?: boolean;
   agentId?: string; // Unique identifier for the agent, used for background tool tracking
+  agentName?: string; // Name of the agent, used for browser tracker
   provider: ModelProvider;
   model?: string;
   baseUrl?: string;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -18,6 +18,8 @@ export * from './tools/browser/browseMessage.js';
 export * from './tools/browser/browseStart.js';
 export * from './tools/browser/PageController.js';
 export * from './tools/browser/BrowserAutomation.js';
+export * from './tools/browser/listBrowsers.js';
+export * from './tools/browser/browserTracker.js';
 
 // Tools - Interaction
 export * from './tools/interaction/subAgent.js';

--- a/packages/agent/src/tools/browser/browseMessage.ts
+++ b/packages/agent/src/tools/browser/browseMessage.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
-import { BackgroundToolStatus } from '../../core/backgroundTools.js';
 import { Tool } from '../../core/types.js';
 import { errorToString } from '../../utils/errorToString.js';
 import { sleep } from '../../utils/sleep.js';
 
+import { BrowserSessionStatus, getBrowserTracker } from './browserTracker.js';
 import { filterPageContent } from './filterPageContent.js';
 import { browserSessions, SelectorType } from './types.js';
 
@@ -72,7 +72,7 @@ export const browseMessageTool: Tool<Parameters, ReturnType> = {
 
   execute: async (
     { instanceId, actionType, url, selector, selectorType, text },
-    { logger, pageFilter, backgroundTools },
+    { logger, pageFilter, agentName = 'default' },
   ): Promise<ReturnType> => {
     // Validate action format
 
@@ -86,6 +86,9 @@ export const browseMessageTool: Tool<Parameters, ReturnType> = {
 
     logger.verbose(`Executing browser action: ${actionType}`);
     logger.verbose(`Webpage processing mode: ${pageFilter}`);
+
+    // Get the browser tracker instance
+    const browserTracker = getBrowserTracker(agentName);
 
     try {
       const session = browserSessions.get(instanceId);
@@ -186,10 +189,10 @@ export const browseMessageTool: Tool<Parameters, ReturnType> = {
           await session.browser.close();
           browserSessions.delete(instanceId);
 
-          // Update background tool registry when browser is explicitly closed
-          backgroundTools.updateToolStatus(
+          // Update browser tracker when browser is explicitly closed
+          browserTracker.updateSessionStatus(
             instanceId,
-            BackgroundToolStatus.COMPLETED,
+            BrowserSessionStatus.COMPLETED,
             {
               closedExplicitly: true,
             },
@@ -206,11 +209,15 @@ export const browseMessageTool: Tool<Parameters, ReturnType> = {
     } catch (error) {
       logger.error('Browser action failed:', { error });
 
-      // Update background tool registry with error status if action fails
-      backgroundTools.updateToolStatus(instanceId, BackgroundToolStatus.ERROR, {
-        error: errorToString(error),
-        actionType,
-      });
+      // Update browser tracker with error status if action fails
+      browserTracker.updateSessionStatus(
+        instanceId,
+        BrowserSessionStatus.ERROR,
+        {
+          error: errorToString(error),
+          actionType,
+        },
+      );
 
       return {
         status: 'error',

--- a/packages/agent/src/tools/browser/browseStart.ts
+++ b/packages/agent/src/tools/browser/browseStart.ts
@@ -1,13 +1,12 @@
 import { chromium } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
-import { BackgroundToolStatus } from '../../core/backgroundTools.js';
 import { Tool } from '../../core/types.js';
 import { errorToString } from '../../utils/errorToString.js';
 import { sleep } from '../../utils/sleep.js';
 
+import { BrowserSessionStatus, getBrowserTracker } from './browserTracker.js';
 import { filterPageContent } from './filterPageContent.js';
 import { browserSessions } from './types.js';
 
@@ -43,7 +42,7 @@ export const browseStartTool: Tool<Parameters, ReturnType> = {
 
   execute: async (
     { url, timeout = 30000 },
-    { logger, headless, userSession, pageFilter, backgroundTools },
+    { logger, headless, userSession, pageFilter, agentName = 'default' },
   ): Promise<ReturnType> => {
     logger.verbose(`Starting browser session${url ? ` at ${url}` : ''}`);
     logger.verbose(
@@ -52,10 +51,11 @@ export const browseStartTool: Tool<Parameters, ReturnType> = {
     logger.verbose(`Webpage processing mode: ${pageFilter}`);
 
     try {
-      const instanceId = uuidv4();
+      // Get the browser tracker instance
+      const browserTracker = getBrowserTracker(agentName);
 
-      // Register this browser session with the background tool registry
-      backgroundTools.registerBrowser(url);
+      // Register this browser session with the tracker
+      const instanceId = browserTracker.registerBrowser(url);
 
       // Launch browser
       const launchOptions = {
@@ -95,10 +95,10 @@ export const browseStartTool: Tool<Parameters, ReturnType> = {
       // Setup cleanup handlers
       browser.on('disconnected', () => {
         browserSessions.delete(instanceId);
-        // Update background tool registry when browser disconnects
-        backgroundTools.updateToolStatus(
+        // Update browser tracker when browser disconnects
+        browserTracker.updateSessionStatus(
           instanceId,
-          BackgroundToolStatus.TERMINATED,
+          BrowserSessionStatus.TERMINATED,
         );
       });
 
@@ -142,10 +142,10 @@ export const browseStartTool: Tool<Parameters, ReturnType> = {
       logger.verbose('Browser session started successfully');
       logger.verbose(`Content length: ${content.length} characters`);
 
-      // Update background tool registry with running status
-      backgroundTools.updateToolStatus(
+      // Update browser tracker with running status
+      browserTracker.updateSessionStatus(
         instanceId,
-        BackgroundToolStatus.RUNNING,
+        BrowserSessionStatus.RUNNING,
         {
           url: url || 'about:blank',
           contentLength: content.length,
@@ -160,7 +160,7 @@ export const browseStartTool: Tool<Parameters, ReturnType> = {
     } catch (error) {
       logger.error(`Failed to start browser: ${errorToString(error)}`);
 
-      // No need to update background tool registry here as we don't have a valid instanceId
+      // No need to update browser tracker here as we don't have a valid instanceId
       // when an error occurs before the browser is properly initialized
 
       return {

--- a/packages/agent/src/tools/browser/browserTracker.ts
+++ b/packages/agent/src/tools/browser/browserTracker.ts
@@ -1,0 +1,160 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { BrowserManager } from './BrowserManager.js';
+import { browserSessions } from './types.js';
+
+// Status of a browser session
+export enum BrowserSessionStatus {
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  ERROR = 'error',
+  TERMINATED = 'terminated',
+}
+
+// Browser session tracking data
+export interface BrowserSessionInfo {
+  id: string;
+  status: BrowserSessionStatus;
+  startTime: Date;
+  endTime?: Date;
+  metadata: {
+    url?: string;
+    contentLength?: number;
+    closedExplicitly?: boolean;
+    error?: string;
+    actionType?: string;
+  };
+}
+
+/**
+ * Registry to keep track of browser sessions
+ */
+export class BrowserTracker {
+  private sessions: Map<string, BrowserSessionInfo> = new Map();
+
+  // Private constructor for singleton pattern
+  constructor(readonly ownerName: string) {}
+
+  // Register a new browser session
+  public registerBrowser(url?: string): string {
+    const id = uuidv4();
+    const session: BrowserSessionInfo = {
+      id,
+      status: BrowserSessionStatus.RUNNING,
+      startTime: new Date(),
+      metadata: {
+        url,
+      },
+    };
+    this.sessions.set(id, session);
+    return id;
+  }
+
+  // Update the status of a browser session
+  public updateSessionStatus(
+    id: string,
+    status: BrowserSessionStatus,
+    metadata?: Record<string, any>,
+  ): boolean {
+    const session = this.sessions.get(id);
+    if (!session) {
+      return false;
+    }
+
+    session.status = status;
+
+    if (
+      status === BrowserSessionStatus.COMPLETED ||
+      status === BrowserSessionStatus.ERROR ||
+      status === BrowserSessionStatus.TERMINATED
+    ) {
+      session.endTime = new Date();
+    }
+
+    if (metadata) {
+      session.metadata = { ...session.metadata, ...metadata };
+    }
+
+    return true;
+  }
+
+  // Get all browser sessions
+  public getSessions(): BrowserSessionInfo[] {
+    return Array.from(this.sessions.values());
+  }
+
+  // Get a specific browser session by ID
+  public getSessionById(id: string): BrowserSessionInfo | undefined {
+    return this.sessions.get(id);
+  }
+
+  // Filter sessions by status
+  public getSessionsByStatus(
+    status: BrowserSessionStatus,
+  ): BrowserSessionInfo[] {
+    return this.getSessions().filter((session) => session.status === status);
+  }
+
+  /**
+   * Cleans up all browser sessions associated with this tracker
+   * @returns A promise that resolves when cleanup is complete
+   */
+  public async cleanup(): Promise<void> {
+    const sessions = this.getSessionsByStatus(BrowserSessionStatus.RUNNING);
+
+    // Create cleanup promises for each session
+    const cleanupPromises = sessions.map((session) =>
+      this.cleanupBrowserSession(session),
+    );
+
+    // Wait for all cleanup operations to complete in parallel
+    await Promise.all(cleanupPromises);
+  }
+
+  /**
+   * Cleans up a browser session
+   * @param session The browser session to clean up
+   */
+  private async cleanupBrowserSession(
+    session: BrowserSessionInfo,
+  ): Promise<void> {
+    try {
+      const browserManager = (
+        globalThis as unknown as { __BROWSER_MANAGER__?: BrowserManager }
+      ).__BROWSER_MANAGER__;
+
+      if (browserManager) {
+        await browserManager.closeSession(session.id);
+      } else {
+        // Fallback to closing via browserSessions if BrowserManager is not available
+        const browserSession = browserSessions.get(session.id);
+        if (browserSession) {
+          await browserSession.page.context().close();
+          await browserSession.browser.close();
+          browserSessions.delete(session.id);
+        }
+      }
+
+      this.updateSessionStatus(session.id, BrowserSessionStatus.COMPLETED);
+    } catch (error) {
+      this.updateSessionStatus(session.id, BrowserSessionStatus.ERROR, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+// Create a singleton instance
+let browserTracker: BrowserTracker | null = null;
+
+/**
+ * Get the singleton instance of the BrowserTracker
+ * @param ownerName The name of the owner (agent) for this tracker
+ * @returns The singleton BrowserTracker instance
+ */
+export function getBrowserTracker(ownerName: string): BrowserTracker {
+  if (!browserTracker) {
+    browserTracker = new BrowserTracker(ownerName);
+  }
+  return browserTracker;
+}

--- a/packages/agent/src/tools/browser/listBrowsers.ts
+++ b/packages/agent/src/tools/browser/listBrowsers.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { Tool } from '../../core/types.js';
+
+import { BrowserSessionStatus, getBrowserTracker } from './browserTracker.js';
+
+const parameterSchema = z.object({
+  status: z
+    .enum(['all', 'running', 'completed', 'error', 'terminated'])
+    .optional()
+    .describe('Filter browser sessions by status (default: "all")'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      'Include detailed metadata about each browser session (default: false)',
+    ),
+});
+
+const returnSchema = z.object({
+  sessions: z.array(
+    z.object({
+      id: z.string(),
+      status: z.string(),
+      startTime: z.string(),
+      endTime: z.string().optional(),
+      runtime: z.number().describe('Runtime in seconds'),
+      url: z.string().optional(),
+      metadata: z.record(z.any()).optional(),
+    }),
+  ),
+  count: z.number(),
+});
+
+type Parameters = z.infer<typeof parameterSchema>;
+type ReturnType = z.infer<typeof returnSchema>;
+
+export const listBrowsersTool: Tool<Parameters, ReturnType> = {
+  name: 'listBrowsers',
+  description: 'Lists all browser sessions and their status',
+  logPrefix: '🔍',
+  parameters: parameterSchema,
+  returns: returnSchema,
+  parametersJsonSchema: zodToJsonSchema(parameterSchema),
+  returnsJsonSchema: zodToJsonSchema(returnSchema),
+
+  execute: async (
+    { status = 'all', verbose = false },
+    { logger, agentName = 'default' },
+  ): Promise<ReturnType> => {
+    logger.verbose(
+      `Listing browser sessions with status: ${status}, verbose: ${verbose}`,
+    );
+
+    // Get the browser tracker instance
+    const browserTracker = getBrowserTracker(agentName);
+
+    // Get all browser sessions
+    const sessions = browserTracker.getSessions();
+
+    // Filter by status if specified
+    const filteredSessions =
+      status === 'all'
+        ? sessions
+        : sessions.filter((session) => {
+            const statusEnum =
+              status.toUpperCase() as keyof typeof BrowserSessionStatus;
+            return session.status === BrowserSessionStatus[statusEnum];
+          });
+
+    // Format the response
+    const formattedSessions = filteredSessions.map((session) => {
+      const now = new Date();
+      const startTime = session.startTime;
+      const endTime = session.endTime || now;
+      const runtime = (endTime.getTime() - startTime.getTime()) / 1000; // in seconds
+
+      return {
+        id: session.id,
+        status: session.status,
+        startTime: startTime.toISOString(),
+        ...(session.endTime && { endTime: session.endTime.toISOString() }),
+        runtime: parseFloat(runtime.toFixed(2)),
+        url: session.metadata.url,
+        ...(verbose && { metadata: session.metadata }),
+      };
+    });
+
+    return {
+      sessions: formattedSessions,
+      count: formattedSessions.length,
+    };
+  },
+
+  logParameters: ({ status = 'all', verbose = false }, { logger }) => {
+    logger.info(
+      `Listing browser sessions with status: ${status}, verbose: ${verbose}`,
+    );
+  },
+
+  logReturns: (output, { logger }) => {
+    logger.info(`Found ${output.count} browser sessions`);
+  },
+};

--- a/packages/agent/src/tools/system/listBackgroundTools.ts
+++ b/packages/agent/src/tools/system/listBackgroundTools.ts
@@ -10,7 +10,7 @@ const parameterSchema = z.object({
     .optional()
     .describe('Filter tools by status (default: "all")'),
   type: z
-    .enum(['all', 'shell', 'browser', 'agent'])
+    .enum(['all', 'shell', 'agent'])
     .optional()
     .describe('Filter tools by type (default: "all")'),
   verbose: z
@@ -39,8 +39,7 @@ type ReturnType = z.infer<typeof returnSchema>;
 
 export const listBackgroundToolsTool: Tool<Parameters, ReturnType> = {
   name: 'listBackgroundTools',
-  description:
-    'Lists all background tools (shells, browsers, agents) and their status',
+  description: 'Lists all background tools (shells, agents) and their status',
   logPrefix: '🔍',
   parameters: parameterSchema,
   returns: returnSchema,


### PR DESCRIPTION
# Decouple Browser Session Tracking from backgroundTools

This PR implements the changes requested in issue #291 to decouple browser session tracking from the backgroundTools implementation.

## Changes Made

1. Created a dedicated `BrowserTracker` class in `packages/agent/src/tools/browser/browserTracker.ts` that is responsible for tracking browser sessions
2. Implemented a new `listBrowsers` tool in `packages/agent/src/tools/browser/listBrowsers.ts` that provides similar functionality to `listBackgroundTools` but focused only on browser sessions
3. Updated `browseStart.ts` and `browseMessage.ts` to use the new `browserTracker` instead of `backgroundTools`
4. Modified `backgroundTools.ts` to remove browser-related code
5. Ensured all tests pass

## Benefits

- Reduced coupling between different tool types
- More focused and maintainable code
- Easier to extend or modify browser-specific functionality
- Clearer separation of concerns

## Testing

All tests pass, confirming that the changes maintain backward compatibility while providing the desired decoupling.

Fixes #291