### PR TITLE
docs: add alternative configuration file locations to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,25 @@ mycoder --githubMode "Work with GitHub issues and PRs"
 
 ## Configuration
 
-MyCoder is configured using a `mycoder.config.js` file in your project root, similar to ESLint and other modern JavaScript tools. This file exports a configuration object with your preferred settings.
+MyCoder is configured using a configuration file in your project. MyCoder supports multiple configuration file locations and formats, similar to ESLint and other modern JavaScript tools.
+
+### Configuration File Locations
+
+MyCoder will look for configuration in the following locations (in order of precedence):
+
+1. `mycoder.config.js` in your project root
+2. `.mycoder.config.js` in your project root
+3. `.config/mycoder.js` in your project root
+4. `.mycoder.rc` in your project root
+5. `.mycoder.rc` in your home directory
+6. `mycoder` field in `package.json`
+7. `~/.config/mycoder/config.js` (XDG standard user configuration)
+
+Multiple file extensions are supported: `.js`, `.ts`, `.mjs`, `.cjs`, `.json`, `.jsonc`, `.json5`, `.yaml`, `.yml`, and `.toml`.
 
 ### Creating a Configuration File
 
-Create a `mycoder.config.js` file in your project root:
+Create a configuration file in your preferred location:
 
 ```js
 // mycoder.config.js

--- a/packages/docs/docs/usage/configuration.md
+++ b/packages/docs/docs/usage/configuration.md
@@ -119,9 +119,21 @@ export default {
 };
 ```
 
-## Configuration File Location
+## Configuration File Locations
 
-The `mycoder.config.js` file should be placed in the root directory of your project. MyCoder will automatically detect and use this file when run from within the project directory or any of its subdirectories.
+MyCoder uses the [c12](https://github.com/unjs/c12) library to load configuration files, which supports multiple file locations and formats. Configuration files are searched in the following order:
+
+1. `mycoder.config.js` (or other supported extensions) in the project root directory
+2. `.mycoder.config.js` (or other supported extensions) in the project root directory
+3. `.config/mycoder.js` (or other supported extensions) in the project root directory
+4. `.mycoder.rc` in the project root directory
+5. `.mycoder.rc` in the user's home directory (global configuration)
+6. Configuration from the `mycoder` field in `package.json`
+7. `~/.config/mycoder/config.js` (XDG standard user configuration)
+
+Supported file extensions include `.js`, `.ts`, `.mjs`, `.cjs`, `.json`, `.jsonc`, `.json5`, `.yaml`, `.yml`, and `.toml`.
+
+MyCoder will automatically detect and use these configuration files when run from within the project directory or any of its subdirectories.
 
 ## Overriding Configuration
 


### PR DESCRIPTION
## Description

This PR adds documentation about alternative configuration file locations supported by MyCoder through the c12 library, as requested in issue #298.

The documentation now includes information about:
- `.mycoder.config.js` in project root (dot-prefixed config file)
- `.config/mycoder.js` in project root (config directory)
- `.mycoder.rc` files (RC config files)
- `~/.config/mycoder/config.js` (XDG standard user configuration)

These changes were made to both:
1. The main README.md file
2. The detailed configuration documentation in packages/docs/docs/usage/configuration.md

## Related Issues
Resolves #298