### PR TITLE
Add think tool for complex reasoning

### DIFF
--- a/packages/agent/src/tools/getTools.ts
+++ b/packages/agent/src/tools/getTools.ts
@@ -19,6 +19,7 @@ import { shellMessageTool } from './shell/shellMessage.js';
 import { shellStartTool } from './shell/shellStart.js';
 import { waitTool } from './sleep/wait.js';
 import { textEditorTool } from './textEditor/textEditor.js';
+import { thinkTool } from './think/think.js';
 
 // Import these separately to avoid circular dependencies
 
@@ -52,6 +53,7 @@ export function getTools(options?: GetToolsOptions): Tool[] {
     sessionMessageTool as unknown as Tool,
     listSessionsTool as unknown as Tool,
     waitTool as unknown as Tool,
+    thinkTool as unknown as Tool,
   ];
 
   // Add agent tools based on the configured mode

--- a/packages/agent/src/tools/think/index.ts
+++ b/packages/agent/src/tools/think/index.ts
@@ -1,0 +1,1 @@
+export * from './think.js';

--- a/packages/agent/src/tools/think/think.test.ts
+++ b/packages/agent/src/tools/think/think.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMockToolContext } from '../getTools.test.js';
+
+import { thinkTool } from './think.js';
+
+describe('thinkTool', () => {
+  const mockContext = getMockToolContext();
+
+  it('should have the correct name and description', () => {
+    expect(thinkTool.name).toBe('think');
+    expect(thinkTool.description).toContain(
+      'Use the tool to think about something',
+    );
+  });
+
+  it('should return the thought that was provided', async () => {
+    const thought =
+      'I need to consider all possible solutions before deciding on an approach.';
+    const result = await thinkTool.execute({ thought }, mockContext);
+
+    expect(result).toEqual({ thought });
+  });
+
+  it('should accept any string as a thought', async () => {
+    const thoughts = [
+      'Simple thought',
+      'Complex thought with multiple steps:\n1. First consider X\n2. Then Y\n3. Finally Z',
+      'A question to myself: what if we tried a different approach?',
+    ];
+
+    for (const thought of thoughts) {
+      const result = await thinkTool.execute({ thought }, mockContext);
+      expect(result).toEqual({ thought });
+    }
+  });
+});

--- a/packages/agent/src/tools/think/think.ts
+++ b/packages/agent/src/tools/think/think.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/**
+ * Schema for the think tool parameters
+ */
+const parameters = z.object({
+  thought: z.string().describe('A thought to think about.'),
+});
+
+/**
+ * Schema for the think tool returns
+ */
+const returns = z.object({
+  thought: z.string().describe('The thought that was processed.'),
+});
+
+/**
+ * Think tool implementation
+ *
+ * This tool allows the agent to explicitly think through a complex problem
+ * without taking any external actions. It serves as a way to document the
+ * agent's reasoning process and can improve problem-solving abilities.
+ *
+ * Based on research from Anthropic showing how a simple "think" tool can
+ * improve Claude's problem-solving skills.
+ */
+export const thinkTool = {
+  name: 'think',
+  description:
+    'Use the tool to think about something. It will not obtain new information or change any state, but just helps with complex reasoning.',
+  parameters,
+  returns,
+  execute: async ({ thought }, { logger }) => {
+    // Log the thought process
+    logger.log(`Thinking: ${thought}`);
+
+    // Simply return the thought - no side effects
+    return {
+      thought,
+    };
+  },
+};


### PR DESCRIPTION
## Description

This PR adds a new `think` tool to the default set of tools in MyCoder. The think tool allows the agent to explicitly think through complex problems without taking any external actions. It serves as a way to document the agent's reasoning process and can improve problem-solving abilities.

## Implementation Details

- Added a new `think` tool in `packages/agent/src/tools/think/`
- Added the tool to the default set of tools in `getTools.ts`
- Implemented tests for the new tool
- All tests are passing

## Motivation

This implementation is based on the request in issue #351, which references research from Anthropic showing how a simple "think" tool can improve Claude's problem-solving skills.

## Related Issues

Resolves #351

## Example Usage

```javascript
await toolAgent.execute({
  name: 'think',
  parameters: {
    thought: 'I need to consider all possible solutions before deciding on an approach.'
  }
});
```

The tool will log the thought process and return the thought without performing any external actions.
