### PR TITLE
docs: add SSH passphrase best practices to GitHub documentation

### DIFF
--- a/packages/docs/docs/usage/github-action.md
+++ b/packages/docs/docs/usage/github-action.md
@@ -158,6 +158,18 @@ Configure Git with appropriate user information for commits made by MyCoder:
 
 This clearly identifies commits made automatically by MyCoder.
 
+### SSH Authentication
+
+When using GitHub Actions with SSH authentication:
+
+1. **Avoid SSH Keys with Passphrases**: For automated environments like GitHub Actions, use SSH keys without passphrases or use alternative authentication methods.
+
+2. **Use HTTPS with PAT**: Consider using HTTPS authentication with a Personal Access Token (PAT) for GitHub Actions to avoid SSH passphrase prompts.
+
+3. **If SSH is Required**: If you must use SSH authentication in GitHub Actions, ensure your workflow doesn't require interactive passphrase entry by:
+   - Using SSH keys without passphrases for automation purposes only
+   - Configuring the SSH agent properly in your workflow
+
 ## Usage Examples
 
 ### Trigger MyCoder on an Issue

--- a/packages/docs/docs/usage/github-mode.md
+++ b/packages/docs/docs/usage/github-mode.md
@@ -138,6 +138,38 @@ If your team uses a complex GitHub workflow (e.g., with code owners, required re
 - **Authentication Problems**: Ensure you've run `gh auth login` successfully
 - **Permission Issues**: Verify you have write access to the repository
 - **Branch Protection**: Some repositories have branch protection rules that may prevent direct pushes
+- **SSH Passphrase Prompts**: If you use SSH keys with passphrases, automated workflows may be interrupted by passphrase prompts
+
+### SSH Passphrase Best Practices
+
+When using GitHub mode with SSH authentication, it's important to properly manage SSH key passphrases to ensure automation works smoothly:
+
+1. **Use SSH Agent**: Configure ssh-agent to remember your passphrase, so you don't need to enter it repeatedly:
+
+   ```bash
+   # Start the ssh-agent in the background
+   eval "$(ssh-agent -s)"
+   
+   # Add your SSH private key to the ssh-agent
+   ssh-add ~/.ssh/id_ed25519  # Replace with your key path
+   ```
+
+2. **Configure SSH Agent to Persist**:
+   - On macOS, you can use the keychain to remember your passphrase:
+     ```bash
+     ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+     ```
+   - On other systems, consider using tools like `keychain` or configuring your desktop environment to start ssh-agent automatically
+
+3. **Create Config File** (optional): Create or edit `~/.ssh/config` to use the ssh-agent:
+   ```
+   Host github.com
+     AddKeysToAgent yes
+     UseKeychain yes  # macOS only
+     IdentityFile ~/.ssh/id_ed25519
+   ```
+
+Without proper SSH agent configuration, MyCoder may be interrupted by passphrase prompts during Git operations, which can cause timeouts in automated environments.
 
 If you encounter any issues with GitHub mode, you can check the GitHub CLI status with:
 


### PR DESCRIPTION
## Description

This PR adds documentation about SSH passphrase best practices to the GitHub mode and GitHub Action documentation sections. It addresses issue #340 where a user mentioned that SSH passphrase prompts can cause timeout issues in automated environments.

### Added Information

1. In the GitHub mode documentation:
   - Added a new bullet point about SSH passphrase prompts to the common issues section
   - Added a detailed "SSH Passphrase Best Practices" section with instructions for configuring ssh-agent
   - Included platform-specific instructions for macOS and other systems

2. In the GitHub Action documentation:
   - Added a new "SSH Authentication" section with best practices for GitHub Actions
   - Provided recommendations on using SSH keys without passphrases in automated environments
   - Suggested HTTPS with PAT as an alternative to SSH for GitHub Actions

### Related Issue
Fixes #340

### Screenshots
N/A