### PR TITLE
Add configurable context window size

### DIFF
--- a/mycoder.config.js
+++ b/mycoder.config.js
@@ -35,6 +35,9 @@ export default {
   //provider: 'openai',
   //model: 'qwen2.5-coder:14b',
   //baseUrl: 'http://192.168.2.66:80/v1-openai',
+  // Manual override for context window size (in tokens)
+  // Useful for models that don't have a known context window size
+  // contextWindow: 16384,
   maxTokens: 4096,
   temperature: 0.7,
 

--- a/packages/agent/src/core/llm/providers/anthropic.ts
+++ b/packages/agent/src/core/llm/providers/anthropic.ts
@@ -121,12 +121,14 @@ export class AnthropicProvider implements LLMProvider {
   name: string = 'anthropic';
   provider: string = 'anthropic.messages';
   model: string;
+  options: AnthropicOptions;
   private client: Anthropic;
   private apiKey: string;
   private baseUrl?: string;
 
   constructor(model: string, options: AnthropicOptions = {}) {
     this.model = model;
+    this.options = options;
     this.apiKey = options.apiKey ?? '';
     this.baseUrl = options.baseUrl;
 
@@ -145,7 +147,11 @@ export class AnthropicProvider implements LLMProvider {
    * Generate text using Anthropic API
    */
   async generateText(options: GenerateOptions): Promise<LLMResponse> {
-    const modelContextWindow = ANTHROPIC_CONTEXT_WINDOWS[this.model];
+    // Use configuration contextWindow if provided, otherwise use model-specific value
+    let modelContextWindow = ANTHROPIC_CONTEXT_WINDOWS[this.model];
+    if (!modelContextWindow && this.options.contextWindow) {
+      modelContextWindow = this.options.contextWindow;
+    }
 
     const { messages, functions, temperature = 0.7, maxTokens, topP } = options;
 

--- a/packages/agent/src/core/llm/providers/ollama.ts
+++ b/packages/agent/src/core/llm/providers/ollama.ts
@@ -24,8 +24,7 @@ import {
 
 // Define model context window sizes for Ollama models
 // These are approximate and may vary based on specific model configurations
-const OLLAMA_MODEL_LIMITS: Record<string, number> = {
-  default: 4096,
+const OLLAMA_CONTEXT_WINDOWS: Record<string, number> = {
   llama2: 4096,
   'llama2-uncensored': 4096,
   'llama2:13b': 4096,
@@ -136,19 +135,21 @@ export class OllamaProvider implements LLMProvider {
     const totalTokens = tokenUsage.input + tokenUsage.output;
 
     // Extract the base model name without specific parameters
-    const baseModelName = this.model.split(':')[0];
     // Check if model exists in limits, otherwise use base model or default
-    const modelMaxTokens =
-      OLLAMA_MODEL_LIMITS[this.model] ||
-      (baseModelName ? OLLAMA_MODEL_LIMITS[baseModelName] : undefined) ||
-      4096; // Default fallback
+    let contextWindow = OLLAMA_CONTEXT_WINDOWS[this.model];
+    if (!contextWindow) {
+      const baseModelName = this.model.split(':')[0];
+      if (baseModelName) {
+        contextWindow = OLLAMA_CONTEXT_WINDOWS[baseModelName];
+      }
+    }
 
     return {
       text: content,
       toolCalls: toolCalls,
       tokenUsage: tokenUsage,
       totalTokens,
-      maxTokens: modelMaxTokens,
+      contextWindow,
     };
   }
 

--- a/packages/agent/src/core/llm/providers/ollama.ts
+++ b/packages/agent/src/core/llm/providers/ollama.ts
@@ -52,10 +52,12 @@ export class OllamaProvider implements LLMProvider {
   name: string = 'ollama';
   provider: string = 'ollama.chat';
   model: string;
+  options: OllamaOptions;
   private client: Ollama;
 
   constructor(model: string, options: OllamaOptions = {}) {
     this.model = model;
+    this.options = options;
     const baseUrl =
       options.baseUrl ||
       process.env.OLLAMA_BASE_URL ||
@@ -141,6 +143,11 @@ export class OllamaProvider implements LLMProvider {
       const baseModelName = this.model.split(':')[0];
       if (baseModelName) {
         contextWindow = OLLAMA_CONTEXT_WINDOWS[baseModelName];
+      }
+
+      // If still no context window, use the one from configuration if available
+      if (!contextWindow && this.options.contextWindow) {
+        contextWindow = this.options.contextWindow;
       }
     }
 

--- a/packages/agent/src/core/llm/providers/openai.ts
+++ b/packages/agent/src/core/llm/providers/openai.ts
@@ -20,8 +20,7 @@ import type {
 } from 'openai/resources/chat';
 
 // Define model context window sizes for OpenAI models
-const OPENAI_MODEL_LIMITS: Record<string, number> = {
-  default: 128000,
+const OPENA_CONTEXT_WINDOWS: Record<string, number> = {
   'o3-mini': 200000,
   'o1-pro': 200000,
   o1: 200000,
@@ -136,14 +135,14 @@ export class OpenAIProvider implements LLMProvider {
 
       // Calculate total tokens and get max tokens for the model
       const totalTokens = tokenUsage.input + tokenUsage.output;
-      const modelMaxTokens = OPENAI_MODEL_LIMITS[this.model] || 8192; // Default fallback
+      const contextWindow = OPENA_CONTEXT_WINDOWS[this.model];
 
       return {
         text: content,
         toolCalls,
         tokenUsage,
         totalTokens,
-        maxTokens: modelMaxTokens,
+        contextWindow,
       };
     } catch (error) {
       throw new Error(`Error calling OpenAI API: ${(error as Error).message}`);

--- a/packages/agent/src/core/llm/providers/openai.ts
+++ b/packages/agent/src/core/llm/providers/openai.ts
@@ -51,6 +51,7 @@ export class OpenAIProvider implements LLMProvider {
   name: string = 'openai';
   provider: string = 'openai.chat';
   model: string;
+  options: OpenAIOptions;
   private client: OpenAI;
   private apiKey: string;
   private baseUrl?: string;
@@ -58,6 +59,7 @@ export class OpenAIProvider implements LLMProvider {
 
   constructor(model: string, options: OpenAIOptions = {}) {
     this.model = model;
+    this.options = options;
     this.apiKey = options.apiKey ?? '';
     this.baseUrl = options.baseUrl;
 
@@ -135,7 +137,12 @@ export class OpenAIProvider implements LLMProvider {
 
       // Calculate total tokens and get max tokens for the model
       const totalTokens = tokenUsage.input + tokenUsage.output;
-      const contextWindow = OPENA_CONTEXT_WINDOWS[this.model];
+
+      // Use configuration contextWindow if provided, otherwise use model-specific value
+      let contextWindow = OPENA_CONTEXT_WINDOWS[this.model];
+      if (!contextWindow && this.options.contextWindow) {
+        contextWindow = this.options.contextWindow;
+      }
 
       return {
         text: content,

--- a/packages/agent/src/core/llm/types.ts
+++ b/packages/agent/src/core/llm/types.ts
@@ -107,5 +107,6 @@ export interface ProviderOptions {
   apiKey?: string;
   baseUrl?: string;
   organization?: string;
+  contextWindow?: number; // Manual override for context window size
   [key: string]: any; // Allow for provider-specific options
 }

--- a/packages/agent/src/core/llm/types.ts
+++ b/packages/agent/src/core/llm/types.ts
@@ -82,7 +82,7 @@ export interface LLMResponse {
   tokenUsage: TokenUsage;
   // Add new fields for context window tracking
   totalTokens?: number; // Total tokens used in this request
-  maxTokens?: number; // Maximum allowed tokens for this model
+  contextWindow?: number; // Maximum allowed tokens for this model
 }
 
 /**

--- a/packages/agent/src/core/toolAgent/__tests__/statusUpdates.test.ts
+++ b/packages/agent/src/core/toolAgent/__tests__/statusUpdates.test.ts
@@ -14,7 +14,7 @@ describe('Status Updates', () => {
   it('should generate a status update with correct token usage information', () => {
     // Setup
     const totalTokens = 50000;
-    const maxTokens = 100000;
+    const contextWindow = 100000;
     const tokenTracker = new TokenTracker('test');
 
     // Mock the context
@@ -33,7 +33,7 @@ describe('Status Updates', () => {
     // Execute
     const statusMessage = generateStatusUpdate(
       totalTokens,
-      maxTokens,
+      contextWindow,
       tokenTracker,
       context,
     );
@@ -58,7 +58,7 @@ describe('Status Updates', () => {
   it('should include active agents, shells, and sessions', () => {
     // Setup
     const totalTokens = 70000;
-    const maxTokens = 100000;
+    const contextWindow = 100000;
     const tokenTracker = new TokenTracker('test');
 
     // Mock the context with active agents, shells, and sessions
@@ -92,7 +92,7 @@ describe('Status Updates', () => {
     // Execute
     const statusMessage = generateStatusUpdate(
       totalTokens,
-      maxTokens,
+      contextWindow,
       tokenTracker,
       context,
     );

--- a/packages/agent/src/core/toolAgent/statusUpdates.ts
+++ b/packages/agent/src/core/toolAgent/statusUpdates.ts
@@ -14,12 +14,14 @@ import { ToolContext } from '../types.js';
  */
 export function generateStatusUpdate(
   totalTokens: number,
-  maxTokens: number,
+  contextWindow: number | undefined,
   tokenTracker: TokenTracker,
   context: ToolContext,
 ): Message {
   // Calculate token usage percentage
-  const usagePercentage = Math.round((totalTokens / maxTokens) * 100);
+  const usagePercentage = contextWindow
+    ? Math.round((totalTokens / contextWindow) * 100)
+    : undefined;
 
   // Get active sub-agents
   const activeAgents = context.agentTracker ? getActiveAgents(context) : [];
@@ -35,7 +37,9 @@ export function generateStatusUpdate(
   // Format the status message
   const statusContent = [
     `--- STATUS UPDATE ---`,
-    `Token Usage: ${formatNumber(totalTokens)}/${formatNumber(maxTokens)} (${usagePercentage}%)`,
+    contextWindow !== undefined
+      ? `Token Usage: ${formatNumber(totalTokens)}/${formatNumber(contextWindow)} (${usagePercentage}%)`
+      : '',
     `Cost So Far: ${tokenTracker.getTotalCost()}`,
     ``,
     `Active Sub-Agents: ${activeAgents.length}`,
@@ -47,9 +51,10 @@ export function generateStatusUpdate(
     `Active Browser Sessions: ${activeSessions.length}`,
     ...activeSessions.map((s) => `- ${s.id}: ${s.description}`),
     ``,
-    usagePercentage >= 50
-      ? `Your token usage is high (${usagePercentage}%). It is recommended to use the 'compactHistory' tool now to reduce context size.`
-      : `If token usage gets high (>50%), consider using the 'compactHistory' tool to reduce context size.`,
+    usagePercentage !== undefined &&
+      (usagePercentage >= 50
+        ? `Your token usage is high (${usagePercentage}%). It is recommended to use the 'compactHistory' tool now to reduce context size.`
+        : `If token usage gets high (>50%), consider using the 'compactHistory' tool to reduce context size.`),
     `--- END STATUS ---`,
   ].join('\n');
 

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -31,6 +31,7 @@ export type ToolContext = {
   apiKey?: string;
   maxTokens: number;
   temperature: number;
+  contextWindow?: number; // Manual override for context window size
   agentTracker: AgentTracker;
   shellTracker: ShellTracker;
   browserTracker: SessionTracker;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,6 +125,9 @@ export default {
   // Model settings
   provider: 'anthropic',
   model: 'claude-3-7-sonnet-20250219',
+  // Manual override for context window size (in tokens)
+  // Useful for models that don't have a known context window size
+  // contextWindow: 16384,
   maxTokens: 4096,
   temperature: 0.7,
 

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -197,6 +197,7 @@ export async function executePrompt(
       model: config.model,
       maxTokens: config.maxTokens,
       temperature: config.temperature,
+      contextWindow: config.contextWindow,
       shellTracker: new ShellTracker('mainAgent'),
       agentTracker: new AgentTracker('mainAgent'),
       browserTracker: new SessionTracker('mainAgent'),

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -9,6 +9,7 @@ export type SharedOptions = {
   readonly model?: string;
   readonly maxTokens?: number;
   readonly temperature?: number;
+  readonly contextWindow?: number;
   readonly profile?: boolean;
   readonly userPrompt?: boolean;
   readonly upgradeCheck?: boolean;
@@ -42,6 +43,10 @@ export const sharedOptions = {
   temperature: {
     type: 'number',
     description: 'Temperature for text generation (0.0-1.0)',
+  } as const,
+  contextWindow: {
+    type: 'number',
+    description: 'Manual override for context window size in tokens',
   } as const,
   interactive: {
     type: 'boolean',

--- a/packages/cli/src/settings/config.ts
+++ b/packages/cli/src/settings/config.ts
@@ -12,6 +12,7 @@ export type Config = {
   model?: string;
   maxTokens: number;
   temperature: number;
+  contextWindow?: number; // Manual override for context window size
   customPrompt: string | string[];
   profile: boolean;
   userPrompt: boolean;
@@ -90,6 +91,7 @@ export const getConfigFromArgv = (argv: ArgumentsCamelCase<SharedOptions>) => {
     model: argv.model,
     maxTokens: argv.maxTokens,
     temperature: argv.temperature,
+    contextWindow: argv.contextWindow,
     profile: argv.profile,
     userSession: argv.userSession,
     headless: argv.headless,

--- a/packages/docs/docs/providers/ollama.md
+++ b/packages/docs/docs/providers/ollama.md
@@ -64,6 +64,11 @@ export default {
   // Optional: Custom base URL (defaults to http://localhost:11434)
   // baseUrl: 'http://localhost:11434',
 
+  // Manual override for context window size (in tokens)
+  // This is particularly useful for Ollama models since MyCoder may not know
+  // the context window size for all possible models
+  contextWindow: 32768, // Example for a 32k context window model
+
   // Other MyCoder settings
   maxTokens: 4096,
   temperature: 0.7,
@@ -80,6 +85,28 @@ Confirmed models with tool calling support:
 - `medragondot/Sky-T1-32B-Preview:latest` - Recommended for MyCoder
 
 If using other models, verify their tool calling capabilities before attempting to use them with MyCoder.
+
+## Context Window Configuration
+
+Ollama supports a wide variety of models, and MyCoder may not have pre-configured context window sizes for all of them. Since the context window size is used to:
+
+1. Track token usage percentage
+2. Determine when to trigger automatic history compaction
+
+It's recommended to manually set the `contextWindow` configuration option when using Ollama models. This ensures proper token tracking and timely history compaction to prevent context overflow.
+
+For example, if using a model with a 32k context window:
+
+```javascript
+export default {
+  provider: 'ollama',
+  model: 'your-model-name',
+  contextWindow: 32768, // 32k context window
+  // other settings...
+};
+```
+
+You can find the context window size for your specific model in the model's documentation or by checking the Ollama model card.
 
 ## Hardware Requirements
 

--- a/packages/docs/docs/usage/configuration.md
+++ b/packages/docs/docs/usage/configuration.md
@@ -23,6 +23,8 @@ export default {
   // Model settings
   provider: 'anthropic',
   model: 'claude-3-7-sonnet-20250219',
+  // Manual override for context window size (in tokens)
+  // contextWindow: 16384,
   maxTokens: 4096,
   temperature: 0.7,
 
@@ -42,10 +44,11 @@ MyCoder will search for configuration in the following places (in order of prece
 
 ### AI Model Selection
 
-| Option     | Description               | Possible Values                                   | Default                      |
-| ---------- | ------------------------- | ------------------------------------------------- | ---------------------------- |
-| `provider` | The AI provider to use    | `anthropic`, `openai`, `mistral`, `xai`, `ollama` | `anthropic`                  |
-| `model`    | The specific model to use | Depends on provider                               | `claude-3-7-sonnet-20250219` |
+| Option          | Description                        | Possible Values                                   | Default                      |
+| --------------- | ---------------------------------- | ------------------------------------------------- | ---------------------------- |
+| `provider`      | The AI provider to use             | `anthropic`, `openai`, `mistral`, `xai`, `ollama` | `anthropic`                  |
+| `model`         | The specific model to use          | Depends on provider                               | `claude-3-7-sonnet-20250219` |
+| `contextWindow` | Manual override for context window | Any positive number                               | Model-specific               |
 
 Example:
 
@@ -55,6 +58,8 @@ export default {
   // Use OpenAI as the provider with GPT-4o model
   provider: 'openai',
   model: 'gpt-4o',
+  // Manually set context window size if needed (e.g., for custom or new models)
+  // contextWindow: 128000,
 };
 ```
 


### PR DESCRIPTION
## Description
Adds a configuration option to manually specify the context window size in `mycoder.config.js`.

## Changes
- Added `contextWindow` configuration option to manually specify the context window size
- Updated all LLM providers to use this configuration when a model's context window is not known
- Updated documentation in README.md and docs package
- Added special documentation for Ollama users since they're more likely to need this feature

## Motivation
When using models that are not known by the tool (especially with Ollama where there are many possible models), users need a way to manually specify the context window size so that:
1. Token usage tracking can work correctly
2. Automatic compaction can be triggered when appropriate

## Related Issues
- Fixes #363 (Add configurable context window size)
- Related to #362 (Make model context window optional)