### PR TITLE
Add support for combining file input and interactive prompts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,9 @@ mycoder "Implement a React component that displays a list of items"
 # Run with a prompt from a file
 mycoder -f prompt.txt
 
+# Combine file input with interactive prompts
+mycoder -f prompt.txt -i
+
 # Disable user prompts for fully automated sessions
 mycoder --userPrompt false "Generate a basic Express.js server"
 

--- a/packages/cli/src/commands/$default.ts
+++ b/packages/cli/src/commands/$default.ts
@@ -246,18 +246,36 @@ export const command: CommandModule<SharedOptions, DefaultArgs> = {
     const config = await loadConfig(argvConfig);
     let prompt: string | undefined;
 
+    // Initialize prompt variable
+    let fileContent: string | undefined;
+    let interactiveContent: string | undefined;
+
     // If promptFile is specified, read from file
     if (argv.file) {
-      prompt = await fs.readFile(argv.file, 'utf-8');
+      fileContent = await fs.readFile(argv.file, 'utf-8');
     }
 
     // If interactive mode
     if (argv.interactive) {
-      prompt = await userPrompt(
-        "Type your request below or 'help' for usage information. Use Ctrl+C to exit.",
-      );
-    } else if (!prompt) {
-      // Use command line prompt if provided
+      // If we already have file content, let the user know
+      const promptMessage = fileContent
+        ? "File content loaded. Add additional instructions below or 'help' for usage information. Use Ctrl+C to exit."
+        : "Type your request below or 'help' for usage information. Use Ctrl+C to exit.";
+
+      interactiveContent = await userPrompt(promptMessage);
+    }
+
+    // Combine inputs or use individual ones
+    if (fileContent && interactiveContent) {
+      // Combine both inputs with a separator
+      prompt = `${fileContent}\n\n--- Additional instructions ---\n\n${interactiveContent}`;
+      console.log('Combined file content with interactive input.');
+    } else if (fileContent) {
+      prompt = fileContent;
+    } else if (interactiveContent) {
+      prompt = interactiveContent;
+    } else if (argv.prompt) {
+      // Use command line prompt if provided and no other input method was used
       prompt = argv.prompt;
     }
 

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -52,13 +52,14 @@ export const sharedOptions = {
     type: 'boolean',
     alias: 'i',
     description:
-      'Run in interactive mode, asking for prompts and enabling corrections during execution (use Ctrl+M to send corrections)',
+      'Run in interactive mode, asking for prompts and enabling corrections during execution (use Ctrl+M to send corrections). Can be combined with -f/--file to append interactive input to file content.',
     default: false,
   } as const,
   file: {
     type: 'string',
     alias: 'f',
-    description: 'Read prompt from a file',
+    description:
+      'Read prompt from a file (can be combined with -i/--interactive)',
   } as const,
   tokenUsage: {
     type: 'boolean',


### PR DESCRIPTION
Closes #383

## Description
This PR adds the ability to use both file input () and interactive prompts () together in the CLI. When both flags are provided, the content from the file is loaded first, and then the user is prompted for additional input. Both inputs are combined into a single context for the agent.

## Changes
- Modified the handler in  to support both file and interactive inputs
- Updated the descriptions for the  and  options in 
- Updated the README.md to document the new capability with examples

## Testing
- Verified that the code compiles successfully
- Verified that all tests pass
- Manual testing to ensure the feature works as expected

## Documentation
- Updated README.md with an example of using the combined mode